### PR TITLE
Allow developer to override the port the server binds to.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,8 @@ services:
       - ./db:/myapp/db
       - ./spec:/myapp/spec
     ports:
-      - "3000:3000"
-      - "1234:1234"
-      - "26162:26126"
+      - "${EXTERNAL_PORT:-3000}:3000"
+      - "${DEBUG_PORT:-26162}:26126"
     command: dockerize -wait tcp://db:5432 ./bin/dockerstart.sh
     depends_on:
       - db


### PR DESCRIPTION
Setting EXTERNAL_PORT and/or DEBUG_PORT in the environment before launching the server with docker-compose will allow the developer to override the ports the server listens on, or the port debugging uses. Useful if running other server that already use the default 3000/26162