### PR TITLE
Use asset helpers to work with Heroku

### DIFF
--- a/app/assets/stylesheets/barnardos/_type.scss
+++ b/app/assets/stylesheets/barnardos/_type.scss
@@ -3,7 +3,7 @@
 
 @font-face {
   font-family: ProximaNova;
-  src: url("pnalt-regular.otf") format("opentype");
+  src: font-url("pnalt-regular.otf") format("opentype");
   font-weight: normal;
   font-style: normal;
 }
@@ -11,7 +11,7 @@
 @font-face {
   font-family: ProximaNova;
   font-weight: bold;
-  src: url("pnalt-medium.otf") format("opentype");
+  src: font-url("pnalt-medium.otf") format("opentype");
 }
 
 .title {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,7 @@
 
 <header role="banner" id="global-header">
   <div id="global-header__logo">
-    <img src="/assets/barnardos-logo.svg" alt="Barnardos logo" />
+    <%= image_tag 'barnardos-logo.svg', alt: 'Barnardos logo' %>
   </div>
   <div id="global-header__menu"></div>
 </header>


### PR DESCRIPTION
Running Rails locally allows you to just put in the name of a font or use /assets/image to access assets but this breaks when deployed to Heroku.

Switched to helpers to load assets so they use the full hashed url on Heroku