### PR TITLE
Incentive vertical radio

### DIFF
--- a/app/helpers/barnardos/action_view/form_helpers.rb
+++ b/app/helpers/barnardos/action_view/form_helpers.rb
@@ -43,7 +43,7 @@ module Barnardos
       #     <label class="radio-group__label" for="age-under12">Under 12 years old</label>
       #   </div>
       # </fieldset>
-      def radio_group_vertical(name, legend, selection_list, value = nil, error: nil, label_options: {}, legend_options: {})
+      def radio_group_vertical(name, legend, selection_list, value = nil, error: nil, legend_options: {})
         content_tag :fieldset, class: "radio-group radio-group__vertical #{'has-error' if error}" do
           # Only render markup if there are options to show
           if selection_list.present?

--- a/app/models/payment_type.rb
+++ b/app/models/payment_type.rb
@@ -1,8 +1,8 @@
 class PaymentType
-  NAME_VALUES = {
+  NAME_VALUES = HashWithIndifferentAccess[{
     cash:    'Cash',
     voucher: 'High street shopping voucher'
-  }
+  }]
 
   def self.allowed_values
     NAME_VALUES.keys.map(&:to_s)

--- a/app/views/research_sessions/incentive.html.erb
+++ b/app/views/research_sessions/incentive.html.erb
@@ -5,58 +5,21 @@
   <%= render 'error_summary' %>
 
   <%= form_for @research_session, url: wizard_path do %>
-      <fieldset class="horizontal-radio-list " id="incentive">
-        <legend class="horizontal-radio-list__legend">
-          Will an incentive be provided?
-        </legend>
+      <%= radio_group_vertical :incentive,
+                               'Will an incentive be provided?',
+                               { '1' => 'Yes', '0' => 'No' },
+                               @research_session.incentive ? '1' : '0'
+      %>
 
-        <div class="horizontal-radio-list__choice">
-          <%= radio_button_tag :incentive,
-                               '1',
-                               @research_session.incentive == true,
-                               class: 'horizontal-radio-list__checkbox',
-                               id: 'incentive-yes' %>
-          <label class="horizontal-radio-list__label" for="incentive-yes">Yes</label>
-        </div>
+      <%= radio_group_vertical :payment_type,
+                               'What form will the incentive take?',
+                               PaymentType::NAME_VALUES,
+                               @research_session.payment_type
+      %>
 
-        <div class="horizontal-radio-list__choice">
-          <%= radio_button_tag :incentive,
-                               '0',
-                               @research_session.incentive == false,
-                               class: 'horizontal-radio-list__checkbox',
-                               id: 'incentive-no' %>
-          <label class="horizontal-radio-list__label" for="incentive-no">No</label>
-        </div>
-
-      </fieldset>
-
-      <fieldset class="horizontal-radio-list " id="paymenttype">
-        <legend class="horizontal-radio-list__legend">
-          What form will the incentive take?
-        </legend>
-
-        <div class="horizontal-radio-list__choice">
-          <%= radio_button_tag :payment_type, :cash,
-                               @research_session.payment_type == 'cash',
-                               class: 'horizontal-radio-list__checkbox',
-                               id: 'payment_type-cash' %>
-          <label class="horizontal-radio-list__label" for="payment_type-cash">Cash</label>
-        </div>
-
-        <div class="horizontal-radio-list__choice">
-          <%= radio_button_tag :payment_type, :voucher,
-                               @research_session.payment_type == 'voucher',
-                               class: 'horizontal-radio-list__checkbox',
-                               id: 'payment_type-voucher'%>
-
-          <label class="horizontal-radio-list__label" for="payment_type-voucher">High street shopping voucher</label>
-        </div>
-      </fieldset>
-
-      <%=
-        labelled_text_field_tag :incentive_value,
-                                'Incentive value',
-                                @research_session.incentive_value %>
+      <%= labelled_text_field_tag :incentive_value,
+                                  'Incentive value',
+                                  @research_session.incentive_value %>
 
       <%= render 'ok_cancel' %>
   <% end %>

--- a/features/step_definitions/question_steps.rb
+++ b/features/step_definitions/question_steps.rb
@@ -25,7 +25,7 @@ When(/^I provide session details – a single age cohort, recording method and i
   end
   click_button 'Continue'
 
-  choose 'incentive-yes'
+  choose 'incentive-1'
 
   choose 'payment_type-cash'
   fill_in 'Incentive value', with: '10.50'


### PR DESCRIPTION
Convert the incentive page to use the `FormHelper#vertical_radio_group` (instead of the ad-hoc HTML it had).