### PR TITLE
Created styles for error summary and clearer messages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,6 +4,7 @@
 @import "barnardos/base";
 @import "barnardos/button";
 @import "barnardos/checkbox";
+@import "barnardos/errorsummary";
 @import "barnardos/page";
 @import "barnardos/radio";
 @import "barnardos/textarea";

--- a/app/assets/stylesheets/barnardos/_errorsummary.scss
+++ b/app/assets/stylesheets/barnardos/_errorsummary.scss
@@ -1,0 +1,12 @@
+.error-summary {
+  background: $error-background;
+  margin: ($gutter * 2) 0;
+  padding:  ($gutter / 2) ($gutter * 2) ($gutter * 2);
+}
+
+.error-summary__item a {
+  color: $error-colour;
+  font-weight: bold;
+  text-decoration: underline;
+  text-transform: se
+}

--- a/app/views/research_sessions/_error_summary.html.erb
+++ b/app/views/research_sessions/_error_summary.html.erb
@@ -1,13 +1,14 @@
 <% if @research_session.errors.any? %>
-    <div class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1">
-      <h1 class="heading-medium" id="error-summary-heading">
-        Incomplete Information
-      </h1>
+  <div class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1">
+    <h2 class=".subtitle-large" id="error-summary-heading">Error summary</h2>
 
-      <ul class="error-summary__list">
-        <% @research_session.errors.full_messages.each do |msg| %>
-            <li class="error-summary__item"><%= msg %></li>
-        <% end %>
-      </ul>
-    </div>
+    <ul class="error-summary__list">
+      <% @research_session.errors.to_hash.each do |key, value| %>
+        <li class="error-summary__item">
+          <a href="#<%= key %>-wrapper"><%= @research_session.errors.full_message(key, value[0]) %></a>
+        </li>
+      <% end %>
+    </ul>
+  </div>
 <% end %>
+

--- a/app/views/research_sessions/age.html.erb
+++ b/app/views/research_sessions/age.html.erb
@@ -1,8 +1,7 @@
 <%= render 'back_link' %>
-
-<h2 class="heading-medium">Age</h2>
 <div class="main-content">
   <%= render 'error_summary' %>
+  <h2 class="heading-medium">Age</h2>
 
   <%= form_for @research_session, url: wizard_path do %>
     <%=

--- a/app/views/research_sessions/focus.html.erb
+++ b/app/views/research_sessions/focus.html.erb
@@ -1,9 +1,7 @@
 <%= render 'back_link' %>
-
-<h2 class="heading-medium">Research Focus</h2>
 <div class="main-content">
   <%= render 'error_summary' %>
-
+  <h2 class="heading-medium">Research Focus</h2>
   <%= form_for @research_session, url: wizard_path do %>
       <%= labelled_text_area_tag(
             :focus,

--- a/app/views/research_sessions/incentive.html.erb
+++ b/app/views/research_sessions/incentive.html.erb
@@ -1,9 +1,7 @@
 <%= render 'back_link' %>
-
-<h2 class="heading-medium">Incentives</h2>
 <div class="main-content">
   <%= render 'error_summary' %>
-
+  <h2 class="heading-medium">Incentives</h2>
   <%= form_for @research_session, url: wizard_path do %>
       <%= radio_group_vertical :incentive,
                                'Will an incentive be provided?',

--- a/app/views/research_sessions/methodologies.html.erb
+++ b/app/views/research_sessions/methodologies.html.erb
@@ -1,9 +1,7 @@
 <%= render 'back_link' %>
-
-<h2 class="heading-medium">Methodologies</h2>
 <div class="main-content">
   <%= render 'error_summary' %>
-
+  <h2 class="heading-medium">Methodologies</h2>
   <%= form_for @research_session, url: wizard_path do %>
       <%= checkbox_group_vertical(
             'methodologies[]',

--- a/app/views/research_sessions/recording.html.erb
+++ b/app/views/research_sessions/recording.html.erb
@@ -1,9 +1,7 @@
 <%= render 'back_link' %>
-
-<h2 class="heading-medium">Recording Methods</h2>
 <div class="main-content">
   <%= render 'error_summary' %>
-
+  <h2 class="heading-medium">Recording Methods</h2>
   <%= form_for @research_session, url: wizard_path do %>
       <%= checkbox_group_vertical(
             'recording_methods[]',

--- a/app/views/research_sessions/researcher.html.erb
+++ b/app/views/research_sessions/researcher.html.erb
@@ -1,9 +1,7 @@
 <%= render 'back_link' %>
-
-<h2 class="heading-medium">What is the name of the lead researcher with the participant?</h2>
 <div class="main-content">
   <%= render 'error_summary' %>
-
+  <h2 class="heading-medium">What is the name of the lead researcher with the participant?</h2>
   <%= form_for @research_session, url: wizard_path do %>
       <div class="first-researcher">
         <%= labelled_text_field_tag :researcher_name, 'Full name', @research_session.researcher_name %>


### PR DESCRIPTION
* Styled error summary
* Put summary at top of screen above title
* Add link from summary item to field to allow navigation to field (fields currently missing this but will add later)

![errors](https://user-images.githubusercontent.com/56056/28588360-36fad9d2-7172-11e7-9138-15d6ba63be96.PNG)
