### PR TITLE
Consent form preview

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,6 +3,7 @@
 @import "barnardos/accessibility";
 @import "barnardos/base";
 @import "barnardos/button";
+@import "barnardos/lists";
 @import "barnardos/checkbox";
 @import "barnardos/errorsummary";
 @import "barnardos/page";

--- a/app/assets/stylesheets/barnardos/_checkbox.scss
+++ b/app/assets/stylesheets/barnardos/_checkbox.scss
@@ -53,7 +53,7 @@ $outer-ring: $inner-ring + ($ring-size * 3);
   box-shadow: 0 0 0 $inner-ring $white, 0 0 0 $border-ring $black;
 }
 
-.checkbox-group__input:disabled + .checkboxo-group__label::before {
+.checkbox-group__input:disabled + .checkbox-group__label::before {
   background: $grey-medium;
   box-shadow: 0 0 0 1px $grey-medium;
   cursor: not-allowed;

--- a/app/assets/stylesheets/barnardos/_lists.scss
+++ b/app/assets/stylesheets/barnardos/_lists.scss
@@ -1,0 +1,9 @@
+.bullet-point-list {
+  list-style-type: disc;
+  margin: 0 $gutter;
+
+  > * {
+    margin: $gutter;
+    line-height: 24px;
+  }
+}

--- a/app/controllers/research_sessions_controller.rb
+++ b/app/controllers/research_sessions_controller.rb
@@ -26,6 +26,10 @@ class ResearchSessionsController < ApplicationController
     @research_session = ResearchSessionPresenter.new(current_research_session)
   end
 
+  def preview_consent_form
+    @research_session = ResearchSessionPresenter.new(current_research_session)
+  end
+
   def update
     @research_session = current_research_session
     @research_session.status = step

--- a/app/models/research_session.rb
+++ b/app/models/research_session.rb
@@ -37,6 +37,14 @@ class ResearchSession < ApplicationRecord
     step_indices.fetch(status.to_sym) >= step_indices.fetch(step)
   end
 
+  def able_to_consent?
+    age.to_sym == :over18
+  end
+
+  def unable_to_consent?
+    !able_to_consent?
+  end
+
 private
   def step_keys
     @@step_keys ||= STEP_PARAMS.keys

--- a/app/presenters/research_session_presenter.rb
+++ b/app/presenters/research_session_presenter.rb
@@ -1,6 +1,6 @@
 class ResearchSessionPresenter < Struct.new(:research_session)
   delegate :age, :focus, :researcher_name, :researcher_other_name,
-           :researcher_email, :researcher_phone,
+           :researcher_email, :researcher_phone, :unable_to_consent?,
            to: :research_session
 
   def methodology_list

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -66,6 +66,6 @@ research so that you can decide whether or not you would like to take part.</p>
     confidential.</p>
 
   <p class="button-bar">
-    <a href="/signconsent" class="button">Continue</a>
+    <%= link_to 'Continue', consent_form_preview_path, class: 'button' %>
   </p>
 </div>

--- a/app/views/research_sessions/preview_consent_form.html.erb
+++ b/app/views/research_sessions/preview_consent_form.html.erb
@@ -1,0 +1,42 @@
+<h1 class="title">Preview: Declaration of consent</h1>
+
+<h2 class="heading-large">Review</h2>
+<p class="super-text">It is important to us that your consent
+  <%= 'for your child' if @research_session.unable_to_consent? %> to
+  take part in this research is freely given and fully informed.</p>
+<p>Please review the following points and indicate your agreement to the
+  statements underneath.</p>
+
+<ul class="bullet-point-list">
+  <li>I have read and understood the Information
+    Sheet for this research project and have had an opportunity to ask
+    questions.
+  </li>
+  <li>I understand that my <%='childʼs' if @research_session.unable_to_consent? %>
+    participation is voluntary and that I am free to withdraw them at any time
+    without giving any reason.
+  </li>
+  <li>I understand that my <%='childʼs' if @research_session.unable_to_consent? %>
+    activities during the research session may be observed and will be recorded.
+    The data captured, in the form of <%= @research_session.recording_methods_list %>,
+    will be used for current and future service development.
+  </li>
+  <li>I understand that this data will be stored securely and
+    covered by the Data Protection Act.
+  </li>
+</ul>
+
+<div class="checkbox-group__choice">
+  <input disabled type="checkbox"
+         id="__print_only_empty_checkbox"
+         class="checkbox-group__input">
+    <label class="checkbox-group__label" for="__print_only_empty_checkbox">
+      I agree to my <%='childʼs' if @research_session.unable_to_consent? %>
+      participation in this research and understand that
+      my childʼs data will be used as explained above.
+    </label>
+</div>
+
+<p class="button-bar">
+  <a class="button print">Print</a>
+</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,10 @@ Rails.application.routes.draw do
 
   resources :questions, only: [:show, :update], controller: 'research_sessions'
 
-  get 'research_session/preview', to: 'research_sessions#preview'
+  get 'research-session/preview', to: 'research_sessions#preview'
+  get 'research-session/preview-consent-form',
+      to: 'research_sessions#preview_consent_form',
+      as: 'consent_form_preview'
 
   get '/gallery/', to: 'gallery#index'
 end

--- a/features/printed_consent_forms.feature
+++ b/features/printed_consent_forms.feature
@@ -3,14 +3,17 @@ Feature:
   I want to generate combinations of printed consent materials
   So that I can get consent from parents and participants without making mistakes
 
-  Scenario: There is one combination of sheet and form
-    When I provide session details – a single age cohort, recording method and incentive details
+  Scenario: The session is for a child
+    When I provide full session details for a child-age cohort
     Then I should see the session review page
     And I should see confirmation that this is a preview
     And I should see the focus of the research along with why
     And I should see an age-specific text block for each research methodology selected
     And I should see a humanised indication of recording methods used
     And I should see which areas have been affected by what I chose
+    When I click continue
+    Then I should see the age-appropriate consent form preview
+    And I should see a way to print it
 
 
 

--- a/features/step_definitions/consent_form_preview_steps.rb
+++ b/features/step_definitions/consent_form_preview_steps.rb
@@ -1,0 +1,9 @@
+Then(/^I should see the age-appropriate consent form preview$/) do
+  expect(page).to have_content('Preview: Declaration of consent')
+  expect(page).to have_content('my child')
+  expect(page).to have_content('your child')
+end
+
+And(/^I should see a way to print it$/) do
+  expect(page).to have_tag('a', with: { class: 'button print' })
+end

--- a/features/step_definitions/question_steps.rb
+++ b/features/step_definitions/question_steps.rb
@@ -1,4 +1,4 @@
-When(/^I provide session details – a single age cohort, recording method and incentive details$/) do
+When(/^I provide full session details for a child-age cohort$/) do
   visit '/'
   click_link 'Create new form'
   choose 'Under 12 years old'

--- a/features/step_definitions/session_review_steps.rb
+++ b/features/step_definitions/session_review_steps.rb
@@ -21,3 +21,7 @@ And(/^I should see which areas have been affected by what I chose$/) do
   some = 5..50
   expect(page).to have_tag('.highlight', count: some)
 end
+
+When(/^I click continue$/) do
+  click_link 'Continue'
+end

--- a/spec/models/research_session_spec.rb
+++ b/spec/models/research_session_spec.rb
@@ -14,6 +14,20 @@ RSpec.describe ResearchSession, type: :model do
       expect(new_session).to be_persisted
     end
 
+    describe '#un/able_to_consent?' do
+      before { session.age = age }
+      context 'is too young' do
+        let(:age) { 'under12' }
+        it { is_expected.not_to be_able_to_consent}
+        it { is_expected.to be_unable_to_consent}
+      end
+      context 'is old enough' do
+        let(:age) { 'over18' }
+        it { is_expected.to be_able_to_consent}
+        it { is_expected.not_to be_unable_to_consent}
+      end
+    end
+
     describe '#has_reached_step?' do
       let(:status) { 'new' }
       before { session.status = status }


### PR DESCRIPTION
Don't quite know what to do with this. It's clearly a thing that produces a consent form, and it's tacked onto the end of the current process after the information sheet preview.  It's really intended as a "fill in the blank" for the [story](https://trello.com/c/QpzZjRjA/16-story-at-the-session-review-page-i-can-print-the-consent-form) that wasn't quite delivered.

But in order to get there (meet acceptance criteria) it needs a print stylesheet.

Ideally, the list items also need styling (default styles guessed at in e2546185b85feb57d6cc6756338b450f140e9463).

<img width="887" alt="screen shot 2017-07-27 at 13 56 21" src="https://user-images.githubusercontent.com/194511/28671112-695c455c-72d3-11e7-89cf-78fbf2476464.png">

