### PR TITLE
Refactor highlighter

### DIFF
--- a/app/assets/stylesheets/app/session_preview.scss
+++ b/app/assets/stylesheets/app/session_preview.scss
@@ -1,3 +1,0 @@
-.highlight {
-  background: $highlight-background-colour;
-}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,13 +3,12 @@
 @import "barnardos/accessibility";
 @import "barnardos/base";
 @import "barnardos/button";
-@import "barnardos/lists";
 @import "barnardos/checkbox";
 @import "barnardos/errorsummary";
+@import "barnardos/highlight";
+@import "barnardos/lists";
 @import "barnardos/page";
 @import "barnardos/radio";
 @import "barnardos/textarea";
 @import "barnardos/textfield";
 @import "barnardos/type";
-
-@import "app/session_preview";

--- a/app/assets/stylesheets/barnardos/_highlight.scss
+++ b/app/assets/stylesheets/barnardos/_highlight.scss
@@ -1,0 +1,8 @@
+@import "barnardos/colours";
+
+.highlight {
+  background: $highlight-background-colour;
+  border-radius: 3px;
+  font-weight: normal;
+  padding: 0 3px;
+}

--- a/app/helpers/research_sessions_helper.rb
+++ b/app/helpers/research_sessions_helper.rb
@@ -1,6 +1,6 @@
 module ResearchSessionsHelper
-  def dynamic(text)
-    content_tag :span, class: 'highlight' do
+  def highlight(text)
+    content_tag :strong, class: 'highlight' do
       text
     end
   end

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -17,11 +17,11 @@ research so that you can decide whether or not you would like to take part.</p>
 
   <h3 class="subtitle-small" id="who">Who is doing the research?</h3>
   <p>
-    <%= dynamic(@research_session.researcher_name) %> is the researcher who will be leading the session.
+    <%= highlight(@research_session.researcher_name) %> is the researcher who will be leading the session.
 
     <% if @research_session.researcher_other_name.present? %>
-      <%= dynamic(@research_session.researcher_name) %>ʼs colleague, <%= dynamic(@research_session.researcher_other_name) %>,
-        may join <%= dynamic(@research_session.researcher_name) %> sometimes to help.
+      <%= highlight(@research_session.researcher_name) %>ʼs colleague, <%= highlight(@research_session.researcher_other_name) %>,
+        may join <%= highlight(@research_session.researcher_name) %> sometimes to help.
     <% end %>
   </p>
 
@@ -31,7 +31,7 @@ research so that you can decide whether or not you would like to take part.</p>
 
   <p>
     With your permission we will record the session using
-    <%= dynamic(@research_session.recording_methods_list) %>. Recording the session helps the
+    <%= highlight(@research_session.recording_methods_list) %>. Recording the session helps the
     researcher and other research team members trying to improve the service, as
     it allows them to review the most useful parts of the session after it has
     finished.
@@ -50,9 +50,9 @@ research so that you can decide whether or not you would like to take part.</p>
   </p>
 
   <h3 class="subtitle-small" id="more">Where can I find out more?</h3>
-  <p><%= dynamic(@research_session.researcher_name) %> will be able to answer further questions about the
-    research. <%= dynamic(@research_session.researcher_name) %> can be contacted by email at
-    <%= dynamic(@research_session.researcher_email) %> or by telephone on <%= dynamic(@research_session.researcher_phone) %>.</p>
+  <p><%= highlight(@research_session.researcher_name) %> will be able to answer further questions about the
+    research. <%= highlight(@research_session.researcher_name) %> can be contacted by email at
+    <%= highlight(@research_session.researcher_email) %> or by telephone on <%= highlight(@research_session.researcher_phone) %>.</p>
   <p>If you have any questions or concerns about the way in which this research has ben conducted then please contact
     Joelle Bradly at <a href="mailto:joelle.bradly@barnardos.org.uk">joelle.bradly@barnardos.org.uk</a></p>
 

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -18,7 +18,8 @@ research so that you can decide whether or not you would like to take part.</p>
   <h3 class="subtitle-small" id="who">Who is doing the research?</h3>
   <p>
     <%= dynamic(@research_session.researcher_name) %> is the researcher who will be leading the session.
-    <% if dynamic(@research_session.researcher_other_name) %>
+
+    <% if @research_session.researcher_other_name.present? %>
       <%= dynamic(@research_session.researcher_name) %>ʼs colleague, <%= dynamic(@research_session.researcher_other_name) %>,
         may join <%= dynamic(@research_session.researcher_name) %> sometimes to help.
     <% end %>

--- a/spec/helpers/research_sessions_helper_spec.rb
+++ b/spec/helpers/research_sessions_helper_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 RSpec.describe ResearchSessionsHelper, :type => :helper do
   include RSpecHtmlMatchers
 
-  describe '#dynamic' do
-    subject(:rendered) { helper.dynamic('some text') }
+  describe '#highlight' do
+    subject(:rendered) { helper.highlight('some text') }
 
-    it 'wraps in a span' do
-      expect(rendered).to have_tag('span.highlight', text: 'some text')
+    it 'wraps in a strong tag with correct class' do
+      expect(rendered).to have_tag('strong.highlight', text: 'some text')
     end
   end
 end


### PR DESCRIPTION
The use of the word dynamic wasn't clear what it meant. Wanted to make the helper more generic and reusable. Also ties the helper function to the associated css class.

The use of the strong tag helps to signify to screens readers that it is significant (which is why something is highlighted).

If a user did not provide another researcher then the other researcher section was still shown as it was creating a highlighted section with no text before testing existence.

Also the other researcher property was present but had no text, so needed to be tested for nil and length > 0

Moved the highlight style into the barnardos folder as it's a generic class that is not tied to a single screen but should be reusable throughout a service.

Added a little style to the highlighters just to give them a some polish.

