### PR TITLE
Use single build entry point

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,6 @@
 require_relative 'config/application'
 
 Rails.application.load_tasks
+
+task(:default).clear
+task default: [:spec, :cucumber, 'npm:lint', 'npm:test:unit']

--- a/circle.yml
+++ b/circle.yml
@@ -11,4 +11,4 @@ machine:
     version: v8.1.3
 test:
   override:
-    - npm run lint && npm run test:unit && bundle exec rake
+    - bundle exec rake

--- a/lib/tasks/npm.rake
+++ b/lib/tasks/npm.rake
@@ -1,0 +1,12 @@
+require 'json'
+
+# Wrap the npm commands in package.json/scripts
+# in their own namespaced tasks
+namespace :npm do
+  package_json = JSON.parse(File.read('package.json'))
+
+  package_json['scripts'].each do |name, _command|
+    desc "#{name} from package.json/scripts"
+    task(name) { puts `npm run #{name}` }
+  end
+end


### PR DESCRIPTION
For [this chore](https://trello.com/c/ofglsmUl/28-run-a-build-healthcheck)

Lets us chain rake commands and have them execute in order. Puts npm
tasks in an npm: namespace, so `rake npm:lint` would run `npm run lint`

This has the side-effect of allowing us to run `bundle exec rake`
locally to run exactly what the CI server will run.