### PR TITLE
Preserve research focus linebreaks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
+  TargetRubyVersion: 2.4.1
   Include:
     - Gemfile
     - Rakefile

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -9,7 +9,7 @@
 <section>
   <h3 class="subtitle-small" id="why">Why is the research being done?</h3>
 
-  <p class="highlight"><%= @research_session.focus %></p>
+  <%= simple_format(@research_session.focus, class: 'highlight') %>
 
   <p>
     It is important that we test the current and future tools and services that

--- a/features/printed_consent_forms.feature
+++ b/features/printed_consent_forms.feature
@@ -7,7 +7,7 @@ Feature:
     When I provide full session details for a child-age cohort
     Then I should see the session review page
     And I should see confirmation that this is a preview
-    And I should see the focus of the research along with why
+    And I should see the formatted focus of the research along with why
     And I should see an age-specific text block for each research methodology selected
     And I should see a humanised indication of recording methods used
     And I should see which areas have been affected by what I chose

--- a/features/step_definitions/question_steps.rb
+++ b/features/step_definitions/question_steps.rb
@@ -16,7 +16,13 @@ When(/^I provide full session details for a child-age cohort$/) do
   end
   click_button 'Continue'
 
-  @focus = 'Fresnel lenses and the under-5s'
+  @focus = <<~TEXT_WITH_DOUBLE_AND_SINGLE_LINEBREAK
+    Fresnel lenses and the under-5s
+    This line break follows a br
+
+    Whereas this becomes its own p
+  TEXT_WITH_DOUBLE_AND_SINGLE_LINEBREAK
+
   fill_in 'What is the focus of your research project?',
           with: @focus
   click_button 'Continue'

--- a/features/step_definitions/session_review_steps.rb
+++ b/features/step_definitions/session_review_steps.rb
@@ -8,8 +8,11 @@ And(/^I should see an age\-specific text block for each research methodology sel
   expect(page).to have_content('Your child will be asked')
 end
 
-And(/^I should see the focus of the research along with why$/) do
-  expect(page).to have_content(@focus)
+And(/^I should see the formatted focus of the research along with why$/) do
+  expect(page).to have_tag('p.highlight', text: /^Fresnel lenses and the under-5s$/)
+  expect(page).to have_tag('p.highlight br')
+  expect(page).to have_tag('p.highlight', text: "Whereas this becomes its own p\n")
+
   expect(page).to have_content('It is important that we test the current and future tools and services')
 end
 

--- a/features/support/action_view.rb
+++ b/features/support/action_view.rb
@@ -1,0 +1,1 @@
+include ActionView::Helpers::TextHelper


### PR DESCRIPTION
[(2) Carry through formatting (i.e. line-breaks) from Form to to Print Format](https://trello.com/c/yA9an8mR/74-2-carry-through-formatting-ie-line-breaks-from-form-to-to-print-format)

As a researcher,
I want my research focus to appear with the minimal formatting I used on the entry page
So that I'm not terribly confused and frustrated

- [x] The formatting I used on the previous Research Focus page has its linebreaks preserved at Session Preview