### PR TITLE
Add support to lint Ruby with Rubocop on Windows

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,3 +35,5 @@ Metrics/MethodLength:
 Metrics/ModuleLength:
   Max: 200
 
+Layout/EndOfLine:
+  EnforcedStyle: lf


### PR DESCRIPTION
Rubocop on Windows defaults to check for line endings native to the OS, in the case of Windows this is CRLF, but the project is set to enforce uniform use of LF.
This Rubocop setting makes the linter check for LF no matter what the OS is used for linting.