### PR TITLE
Link back to steps from preview

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,3 +37,7 @@ Metrics/ModuleLength:
 
 Layout/EndOfLine:
   EnforcedStyle: lf
+
+Style/PredicateName:
+  Exclude:
+    - 'spec/**/*'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -251,16 +251,6 @@ Style/PercentLiteralDelimiters:
     - 'lib/tasks/cucumber.rake'
     - 'spec/controllers/research_sessions_controller_spec.rb'
 
-# Offense count: 1
-# Configuration parameters: NamePrefix, NamePrefixBlacklist, NameWhitelist.
-# NamePrefix: is_, has_, have_
-# NamePrefixBlacklist: is_, has_, have_
-# NameWhitelist: is_a?
-Style/PredicateName:
-  Exclude:
-    - 'spec/**/*'
-    - 'app/models/research_session.rb'
-
 # Offense count: 80
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles, ConsistentQuotesInMultiline.

--- a/app/assets/stylesheets/app/session_preview.scss
+++ b/app/assets/stylesheets/app/session_preview.scss
@@ -1,3 +1,3 @@
-.highlight {
+.editable, .editable > p {
   background: $highlight-background-colour;
 }

--- a/app/controllers/research_sessions_controller.rb
+++ b/app/controllers/research_sessions_controller.rb
@@ -2,7 +2,7 @@ class ResearchSessionsController < ApplicationController
   helper Barnardos::ActionView::FormHelpers
 
   include Wicked::Wizard
-  steps *ResearchSession::STEP_PARAMS.keys
+  steps *ResearchSession::Steps::PARAMS.keys
 
   rescue_from Wicked::Wizard::InvalidStepError do
     render status: 404,
@@ -55,7 +55,7 @@ private
   end
 
   def question_params
-    params.permit(ResearchSession::STEP_PARAMS[step])
+    params.permit(ResearchSession::Steps::PARAMS[step])
   end
 end
 

--- a/app/helpers/research_sessions_helper.rb
+++ b/app/helpers/research_sessions_helper.rb
@@ -4,8 +4,6 @@ module ResearchSessionsHelper
 
     step_for_attr = ResearchSession::Steps.instance.attr_to_step(attr)
 
-    link_to question_path(step_for_attr) do
-      content_tag(:span, value, class: 'highlight')
-    end
+    link_to value, question_path(step_for_attr), class: 'editable'
   end
 end

--- a/app/helpers/research_sessions_helper.rb
+++ b/app/helpers/research_sessions_helper.rb
@@ -1,7 +1,11 @@
 module ResearchSessionsHelper
-  def dynamic(text)
-    content_tag :span, class: 'highlight' do
-      text
+  def edit_link_for(attr, &block)
+    value = block_given? ? capture(&block) : @research_session.send(attr)
+
+    step_for_attr = ResearchSession::Steps.instance.attr_to_step(attr)
+
+    link_to question_path(step_for_attr) do
+      content_tag(:span, value, class: 'highlight')
     end
   end
 end

--- a/app/models/research_session.rb
+++ b/app/models/research_session.rb
@@ -9,29 +9,29 @@ class ResearchSession < ApplicationRecord
   }]
 
   validates :age, inclusion: { in: Age.allowed_values },
-            if: -> (session) { session.has_reached_step?(:age) }
+            if: -> (session) { session.reached_step?(:age) }
   validates :methodologies,
             has_at_least_one: { of: Methodologies.allowed_values },
-            if: -> (session) { session.has_reached_step?(:methodologies) }
+            if: -> (session) { session.reached_step?(:methodologies) }
   validates :recording_methods,
             has_at_least_one: { of: RecordingMethods.allowed_values },
-            if: -> (session) { session.has_reached_step?(:recording) }
+            if: -> (session) { session.reached_step?(:recording) }
   validates :focus, presence: true,
-            if: -> (session) { session.has_reached_step?(:focus) }
+            if: -> (session) { session.reached_step?(:focus) }
   validates :researcher_name, presence: true,
-            if: -> (session) { session.has_reached_step?(:researcher) }
+            if: -> (session) { session.reached_step?(:researcher) }
   validates :researcher_phone, presence: true,
-            if: -> (session) { session.has_reached_step?(:researcher) }
+            if: -> (session) { session.reached_step?(:researcher) }
   validates :researcher_email, presence: true,
-            if: -> (session) { session.has_reached_step?(:researcher) }
+            if: -> (session) { session.reached_step?(:researcher) }
   validates :researcher_email, format: /@/,
-    if: -> (session) { session.researcher_email.present? && session.has_reached_step?(:researcher) }
+    if: -> (session) { session.researcher_email.present? && session.reached_step?(:researcher) }
   validates :payment_type, inclusion: { in: PaymentType.allowed_values },
-    if: -> (session) { session.incentive && session.has_reached_step?(:incentive) }
+    if: -> (session) { session.incentive && session.reached_step?(:incentive) }
   validates :incentive_value, presence: true,
-    if: -> (session) { session.incentive && session.has_reached_step?(:incentive) }
+    if: -> (session) { session.incentive && session.reached_step?(:incentive) }
 
-  def has_reached_step?(step)
+  def reached_step?(step)
     step = step.to_sym
     return false if status == 'new'
     step_indices.fetch(status.to_sym) >= step_indices.fetch(step)

--- a/app/models/research_session/steps.rb
+++ b/app/models/research_session/steps.rb
@@ -1,0 +1,33 @@
+require 'singleton'
+
+class ResearchSession
+  class Steps
+    include Singleton
+
+    PARAMS = ActiveSupport::OrderedHash[{
+      age:           [:age],
+      methodologies: [methodologies: []],
+      recording:     [recording_methods: []],
+      focus:         [:focus],
+      researcher:    [:researcher_name, :researcher_phone,
+                      :researcher_email, :researcher_other_name],
+      incentive:     [:incentive, :payment_type, :incentive_value]
+    }]
+
+    def reached_step?(session, step)
+      step = step.to_sym
+      return false if session.status == 'new'
+      step_indices.fetch(session.status.to_sym) >= step_indices.fetch(step)
+    end
+
+    def step_keys
+      @step_keys ||= PARAMS.keys
+    end
+
+    ##
+    # A hash of step names as symbols to numeric indices, with age: 0, name: 1 etc
+    def step_indices
+      @step_indices ||= step_keys.each_with_index.map { |step, index| [step, index] }.to_h
+    end
+  end
+end

--- a/app/models/research_session/steps.rb
+++ b/app/models/research_session/steps.rb
@@ -25,6 +25,24 @@ class ResearchSession
     end
 
     ##
+    # Returns a hash of attribute names to step names in the wizard
+    def attr_to_step(attr)
+      @attrs_to_steps ||=
+        PARAMS.each_with_object({}) do |kv, params_to_steps|
+          step, params = *kv
+          case params.first
+          when Symbol
+            params.each { |param| params_to_steps[param] = step }
+          when Hash
+            params.first.keys.each { |param| params_to_steps[param] = step }
+          end
+        end
+      @attrs_to_steps.fetch(attr)
+    end
+
+  private
+
+    ##
     # A hash of step names as symbols to numeric indices, with age: 0, name: 1 etc
     def step_indices
       @step_indices ||= step_keys.each_with_index.map { |step, index| [step, index] }.to_h

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -9,7 +9,9 @@
 <section>
   <h3 class="subtitle-small" id="why">Why is the research being done?</h3>
 
-  <%= simple_format(@research_session.focus, class: 'highlight') %>
+  <%= edit_link_for(:focus) do %>
+    <%= simple_format(@research_session.focus, class: 'highlight') %>
+  <% end %>
 
   <p>
     It is important that we test the current and future tools and services that
@@ -20,24 +22,27 @@
 <section>
   <h3 class="subtitle-small" id="who">Who is doing the research?</h3>
   <p>
-    <%= dynamic(@research_session.researcher_name) %> is the researcher who will be leading the session.
-    <% if dynamic(@research_session.researcher_other_name) %>
-      <%= dynamic(@research_session.researcher_name) %>ʼs colleague, <%= dynamic(@research_session.researcher_other_name) %>,
-        may join <%= dynamic(@research_session.researcher_name) %> sometimes to help.
+    <%= edit_link_for(:researcher_name) %> is the researcher who will be leading the session.
+    <% if @research_session.researcher_other_name %>
+      <%= edit_link_for(:researcher_name) %>ʼs colleague,
+      <%= edit_link_for(:researcher_other_name) %>,
+      may join <%= edit_link_for(:researcher_name) %> sometimes to help.
     <% end %>
   </p>
 </section>
 <section>
   <h3 class="subtitle-small" id="what">What will happen next?</h3>
 
-  <%= @research_session.methodology_list %>
+  <%= edit_link_for(:methodologies) do %>
+    <%= @research_session.methodology_list %>
+  <% end %>
 
   <p>
     With your permission we will record the session using
-    <%= dynamic(@research_session.recording_methods_list) %>. Recording the session helps the
-    researcher and other research team members trying to improve the service, as
-    it allows them to review the most useful parts of the session after it has
-    finished.
+    <%= edit_link_for(:recording_methods) { @research_session.recording_methods_list } %>.
+    Recording the session helps the researcher and other research team members
+    trying to improve the service, asit allows them to review the most useful
+    parts of the session after it hasfinished.
   </p>
 </section>
 <section>
@@ -55,11 +60,12 @@
 </section>
 <section>
   <h3 class="subtitle-small" id="more">Where can I find out more?</h3>
-  <p><%= dynamic(@research_session.researcher_name) %> will be able to answer further questions about the
-    research. <%= dynamic(@research_session.researcher_name) %> can be contacted by email at
-    <%= dynamic(@research_session.researcher_email) %> or by telephone on <%= dynamic(@research_session.researcher_phone) %>.</p>
-  <p>If you have any questions or concerns about the way in which this research has ben conducted then please contact
-    Joelle Bradly at <a href="mailto:joelle.bradly@barnardos.org.uk">joelle.bradly@barnardos.org.uk</a></p>
+  <p><%= edit_link_for(:researcher_name) %> will be able to answer further questions about the
+    research. <%= edit_link_for(:researcher_name) %> can be contacted by email at
+    <%= edit_link_for(:researcher_email) %> or by telephone on <%= edit_link_for(:researcher_phone) %>.</p>
+  <p>If you have any questions or concerns about the way in which this research has
+    been conducted then please contactJoelle Bradly at
+    <a href="mailto:joelle.bradly@barnardos.org.uk">joelle.bradly@barnardos.org.uk</a></p>
 </section>
 <section>
   <h3 class="subtitle-small" id="private">Will what I say be kept confidential?</h3>

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -10,7 +10,7 @@
   <h3 class="subtitle-small" id="why">Why is the research being done?</h3>
 
   <%= edit_link_for(:focus) do %>
-    <%= simple_format(@research_session.focus, class: 'highlight') %>
+    <%= simple_format(@research_session.focus) %>
   <% end %>
 
   <p>

--- a/features/printed_consent_forms.feature
+++ b/features/printed_consent_forms.feature
@@ -10,7 +10,7 @@ Feature:
     And I should see the formatted focus of the research along with why
     And I should see an age-specific text block for each research methodology selected
     And I should see a humanised indication of recording methods used
-    And I should see which areas have been affected by what I chose
+    And I should see links back to edit things that I provided
     When I click continue
     Then I should see the age-appropriate consent form preview
     And I should see a way to print it

--- a/features/step_definitions/session_review_steps.rb
+++ b/features/step_definitions/session_review_steps.rb
@@ -22,9 +22,10 @@ And(/^I should see a humanised indication of recording methods used$/) do
   expect(page).to have_content('audio, video, and written notes')
 end
 
-And(/^I should see which areas have been affected by what I chose$/) do
-  some = 5..50
-  expect(page).to have_tag('.highlight', count: some)
+And(/^I should see links back to edit things that I provided$/) do
+  ResearchSession::Steps.instance.step_keys.each do |step|
+    expect(page).to have_tag('a', href: question_path(step))
+  end
 end
 
 When(/^I click continue$/) do

--- a/features/step_definitions/session_review_steps.rb
+++ b/features/step_definitions/session_review_steps.rb
@@ -9,9 +9,9 @@ And(/^I should see an age\-specific text block for each research methodology sel
 end
 
 And(/^I should see the formatted focus of the research along with why$/) do
-  expect(page).to have_tag('p.highlight', text: /^Fresnel lenses and the under-5s$/)
-  expect(page).to have_tag('p.highlight br')
-  expect(page).to have_tag('p.highlight', text: "Whereas this becomes its own p\n")
+  expect(page).to have_tag('.editable p', text: /^Fresnel lenses and the under-5s$/)
+  expect(page).to have_tag('.editable p br')
+  expect(page).to have_tag('.editable p', text: "Whereas this becomes its own p\n")
 
   expect(page).to have_content(
     'It is important that we test the current and future tools and services'

--- a/spec/helpers/research_sessions_helper_spec.rb
+++ b/spec/helpers/research_sessions_helper_spec.rb
@@ -3,11 +3,41 @@ require 'rails_helper'
 RSpec.describe ResearchSessionsHelper, :type => :helper do
   include RSpecHtmlMatchers
 
-  describe '#dynamic' do
-    subject(:rendered) { helper.dynamic('some text') }
+  describe '#edit_link_for' do
+    let(:session) { double('ResearchSession') }
+    let(:block) { nil }
 
-    it 'wraps in a span' do
-      expect(rendered).to have_tag('span.highlight', text: 'some text')
+    before do
+      allow(session).to receive(attr).and_return('Some attr value')
+      allow(session).to receive(attr).with(:i_dont_exist).and_raise(NameError)
+      @research_session = session
+    end
+
+    subject(:rendered) { helper.edit_link_for(attr, &block) }
+
+    context "the attr isn't on the session" do
+      let(:attr) { :i_dont_exist }
+      it 'raises a KeyError' do
+        expect { helper.edit_link_for(attr) }.to raise_error(KeyError, /i_dont_exist/)
+      end
+    end
+
+    context 'the attr is one we know about' do
+      let(:attr) { :researcher_name }
+
+      context 'a researcher attribute' do
+        it 'links to the researcher step' do
+          expect(rendered).to have_tag('a', href: '/questions/researcher', text: /Some attr value/)
+        end
+      end
+
+      context 'a custom block is given for content' do
+        let(:block) { -> { 'I learned it in a block' } }
+
+        it 'uses the block content' do
+          expect(rendered).to have_tag('a', text: /I learned it in a block/)
+        end
+      end
     end
   end
 end

--- a/spec/models/research_session/steps_spec.rb
+++ b/spec/models/research_session/steps_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe ResearchSession::Steps do
+  let(:status)  { 'new' }
+  let(:session) { spy('ResearchSession') }
+  let(:steps)   { ResearchSession::Steps.instance }
+
+  before  { allow(session).to receive(:status).and_return(status) }
+
+  subject { steps.reached_step?(session, at_least) }
+
+  context 'no state given beyond default new' do
+    let(:at_least) { 'methodologies' }
+
+    it { is_expected.to be false }
+  end
+  context 'invalid state given beyond the first state of new' do
+    let(:status) { 'age' }
+    it 'raises an error' do
+      expect { steps.reached_step?(session, 'invalid-state') }.to \
+        raise_error(KeyError, /not found/)
+    end
+  end
+  context 'we are at the first stage' do
+    let(:status)   { 'age' }
+    let(:at_least) { 'methodologies' }
+
+    it { is_expected.to be false }
+  end
+  context 'we have reached the stage we are testing' do
+    let(:status)   { 'methodologies' }
+    let(:at_least) { 'methodologies' }
+
+    it { is_expected.to be true }
+  end
+  context 'we are past the stage we are testing' do
+    let(:status)   { 'incentive' }
+    let(:at_least) { 'methodologies' }
+
+    it { is_expected.to be true }
+  end
+end

--- a/spec/models/research_session/steps_spec.rb
+++ b/spec/models/research_session/steps_spec.rb
@@ -1,42 +1,72 @@
 require 'rails_helper'
 
 RSpec.describe ResearchSession::Steps do
-  let(:status)  { 'new' }
-  let(:session) { spy('ResearchSession') }
-  let(:steps)   { ResearchSession::Steps.instance }
+  let(:steps) { ResearchSession::Steps.instance }
 
-  before  { allow(session).to receive(:status).and_return(status) }
+  describe '#reached_step?' do
+    let(:status)  { 'new' }
+    let(:session) { spy('ResearchSession') }
 
-  subject { steps.reached_step?(session, at_least) }
+    before  { allow(session).to receive(:status).and_return(status) }
 
-  context 'no state given beyond default new' do
-    let(:at_least) { 'methodologies' }
+    subject { steps.reached_step?(session, at_least) }
 
-    it { is_expected.to be false }
-  end
-  context 'invalid state given beyond the first state of new' do
-    let(:status) { 'age' }
-    it 'raises an error' do
-      expect { steps.reached_step?(session, 'invalid-state') }.to \
-        raise_error(KeyError, /not found/)
+    context 'no state given beyond default new' do
+      let(:at_least) { 'methodologies' }
+
+      it { is_expected.to be false }
+    end
+    context 'invalid state given beyond the first state of new' do
+      let(:status) { 'age' }
+      it 'raises an error' do
+        expect { steps.reached_step?(session, 'invalid-state') }.to \
+          raise_error(KeyError, /not found/)
+      end
+    end
+    context 'we are at the first stage' do
+      let(:status)   { 'age' }
+      let(:at_least) { 'methodologies' }
+
+      it { is_expected.to be false }
+    end
+    context 'we have reached the stage we are testing' do
+      let(:status)   { 'methodologies' }
+      let(:at_least) { 'methodologies' }
+
+      it { is_expected.to be true }
+    end
+    context 'we are past the stage we are testing' do
+      let(:status)   { 'incentive' }
+      let(:at_least) { 'methodologies' }
+
+      it { is_expected.to be true }
     end
   end
-  context 'we are at the first stage' do
-    let(:status)   { 'age' }
-    let(:at_least) { 'methodologies' }
 
-    it { is_expected.to be false }
-  end
-  context 'we have reached the stage we are testing' do
-    let(:status)   { 'methodologies' }
-    let(:at_least) { 'methodologies' }
+  describe '#attr_to_step' do
+    subject(:step) { steps.attr_to_step(attr) }
 
-    it { is_expected.to be true }
-  end
-  context 'we are past the stage we are testing' do
-    let(:status)   { 'incentive' }
-    let(:at_least) { 'methodologies' }
+    context 'the attr does not exist' do
+      it 'raises a KeyError' do
+        expect { steps.attr_to_step('i-dont-exist') }.to \
+          raise_error(KeyError, /i-dont-exist/)
+      end
+    end
 
-    it { is_expected.to be true }
+    context 'the attr is a researcher attribute' do
+      let(:attr) { :researcher_name }
+
+      it 'goes to the researcher page' do
+        expect(step).to eql(:researcher)
+      end
+    end
+
+    context 'the attr is a methodologies (array) attribute' do
+      let(:attr) { :methodologies }
+
+      it 'goes to the methodologies page' do
+        expect(step).to eql(:methodologies)
+      end
+    end
   end
 end

--- a/spec/models/research_session_spec.rb
+++ b/spec/models/research_session_spec.rb
@@ -29,40 +29,11 @@ RSpec.describe ResearchSession, type: :model do
     end
 
     describe '#reached_step?' do
-      let(:status) { 'new' }
-      before { session.status = status }
-
-      subject { session.reached_step?(at_least) }
-
-      context 'no state given beyond default new' do
-        let(:at_least) { 'methodologies' }
-
-        it { is_expected.to be false }
-      end
-      context 'invalid state given beyond the first state of new' do
-        let(:status) { 'age' }
-        it 'raises an error' do
-          expect { session.reached_step?('invalid-state') }.to \
-            raise_error(KeyError, /not found/)
-        end
-      end
-      context 'we are at the first stage' do
-        let(:status)   { 'age' }
-        let(:at_least) { 'methodologies' }
-
-        it { is_expected.to be false }
-      end
-      context 'we have reached the stage we are testing' do
-        let(:status)   { 'methodologies' }
-        let(:at_least) { 'methodologies' }
-
-        it { is_expected.to be true }
-      end
-      context 'we are past the stage we are testing' do
-        let(:status)   { 'incentive' }
-        let(:at_least) { 'methodologies' }
-
-        it { is_expected.to be true }
+      it 'passes through to Steps' do
+        steps_spy = spy('Steps')
+        allow(ResearchSession::Steps).to receive(:instance).and_return(steps_spy)
+        session.reached_step?(:methodologies)
+        expect(steps_spy).to have_received(:reached_step?)
       end
     end
 

--- a/spec/models/research_session_spec.rb
+++ b/spec/models/research_session_spec.rb
@@ -28,11 +28,11 @@ RSpec.describe ResearchSession, type: :model do
       end
     end
 
-    describe '#has_reached_step?' do
+    describe '#reached_step?' do
       let(:status) { 'new' }
       before { session.status = status }
 
-      subject { session.has_reached_step?(at_least) }
+      subject { session.reached_step?(at_least) }
 
       context 'no state given beyond default new' do
         let(:at_least) { 'methodologies' }
@@ -42,7 +42,7 @@ RSpec.describe ResearchSession, type: :model do
       context 'invalid state given beyond the first state of new' do
         let(:status) { 'age' }
         it 'raises an error' do
-          expect { session.has_reached_step?('invalid-state') }.to \
+          expect { session.reached_step?('invalid-state') }.to \
             raise_error(KeyError, /not found/)
         end
       end


### PR DESCRIPTION
# [(2) Return to Previously Completed Steps from Preview in order to Edit](https://trello.com/c/gXdB0ohR/94-2-return-to-previously-completed-steps-from-preview-in-order-to-edit)

As a researcher
I want to indicate the thing I want to edit in the preview
So that I can go directly to that page

- [x] Editable parts in the session review link back to the wizard step on which you can edit them

## Tech notes

- We've moved things related to wizard steps into a nested class `ResearchSession::Steps`
- There is no class method called `h` before you ask, @sl33p 

## Things to do

- Make it look not godawful (please, Obi-Wan-@ztolley, you are my only hope)

## Bugs encountered on the way (now to be separate PRs)

- [Fix header mismatches in three wizard steps](6b45aa6)
- [Move focus.html.erb label_options together](2fe3ffec5453357f788843235c3a93a371bfdc31)


