### PR TITLE
Add Hotjar script for feedback

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,3 +10,5 @@
 const HighlightControl = require('../components/highlightcontrol')
 
 HighlightControl.init()
+
+require('../vendor/hotjar')

--- a/app/javascript/vendor/hotjar.js
+++ b/app/javascript/vendor/hotjar.js
@@ -1,0 +1,12 @@
+/*
+ Hotjar Tracking Code for http://consent-form.barnardos.digital/
+*/
+
+(function(h,o,t,j,a,r){
+  h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+  h._hjSettings={hjid:582685,hjsv:5};
+  a=o.getElementsByTagName('head')[0];
+  r=o.createElement('script');r.async=1;
+  r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+  a.appendChild(r);
+})(window,document,'//static.hotjar.com/c/hotjar-','.js?sv=');


### PR DESCRIPTION
# [(3) Add Feedback Functionality](https://trello.com/c/fR8jrCcx/77-3-add-feedback-functionality)

**NB: Ad blockers will kill this - disable or whitelist**

Added to `app/javascript/vendor`. It's a single anonymous function that
doesn't need to be referenced anywhere, so it's included with a require
that doesn't save any module reference.

If this is working you'll see a feedback logo at the bottom right of
your browser:

<img width="520" alt="screen shot 2017-08-03 at 15 57 20" src="https://user-images.githubusercontent.com/194511/28928212-92a16758-7864-11e7-9290-ce03f4ee4ad3.png">