### PR TITLE
Fix checkbox persistence

### DIFF
--- a/app/helpers/barnardos/action_view/form_helpers.rb
+++ b/app/helpers/barnardos/action_view/form_helpers.rb
@@ -130,6 +130,8 @@ module Barnardos
 
       def checkbox_group_vertical(name, legend, selection_list, values = [],
                                   error: nil, legend_options: {})
+        values = values&.map(&:to_s)
+
         content_tag(
           :fieldset,
           class: "checkbox-group checkbox-group__vertical #{'has-error' if error}"
@@ -150,7 +152,7 @@ module Barnardos
             # Render checkbox options
             selection_list.each do |selection_item_value, selection_item_text|
               id = "#{name}-#{selection_item_value}"
-              checked = values&.include? selection_item_value
+              checked = values&.include?(selection_item_value.to_s)
               concat(
                 content_tag(:div, class: 'checkbox-group__choice') do
                   concat(

--- a/spec/helpers/barnardos/checkbox_helper_spec.rb
+++ b/spec/helpers/barnardos/checkbox_helper_spec.rb
@@ -106,11 +106,7 @@ RSpec.describe Barnardos::ActionView::FormHelpers, :type => :helper do
     end
 
     context 'a legend with an optional hint specified' do
-      let(:legend_options) do
-        {
-          :hint => 'A hint'
-        }
-      end
+      let(:legend_options) { { :hint => 'A hint' } }
 
       it 'includes an optional hint in the legend' do
         expect(rendered).to have_tag(

--- a/spec/helpers/barnardos/checkbox_helper_spec.rb
+++ b/spec/helpers/barnardos/checkbox_helper_spec.rb
@@ -128,17 +128,31 @@ RSpec.describe Barnardos::ActionView::FormHelpers, :type => :helper do
     end
 
     context 'multiple field values are supplied' do
-      let(:values) { ['one', 'three'] }
+      context 'as strings' do
+        let(:values) { ['one', 'three'] }
 
-      it 'marks multiple checkboxes for multiple values' do
-        expect(rendered).to have_tag('#age-one[checked="checked"]', checked: true)
-        expect(rendered).to have_tag('#age-three[checked="checked"]', checked: true)
+        it 'marks multiple checkboxes for multiple values' do
+          expect(rendered).to have_tag('#age-one[checked="checked"]', checked: true)
+          expect(rendered).to have_tag('#age-three[checked="checked"]', checked: true)
+        end
+
+        it 'does not check inputs that have not been selected' do
+          expect(rendered).to have_tag('#age-two:not([checked])')
+        end
       end
 
-      it 'does not check inputs that have not been selected' do
-        expect(rendered).to have_tag('#age-two:not([checked])')
-      end
+      context 'as symbols' do
+        let(:values) { [:one, :three] }
 
+        it 'marks multiple checkboxes for multiple values' do
+          expect(rendered).to have_tag('#age-one[checked="checked"]', checked: true)
+          expect(rendered).to have_tag('#age-three[checked="checked"]', checked: true)
+        end
+
+        it 'does not check inputs that have not been selected' do
+          expect(rendered).to have_tag('#age-two:not([checked])')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
# [Checkboxes aren't getting their values filled in on recording methods/methodologies](https://trello.com/c/uX6UGq3f/103-checkboxes-arent-getting-their-values-filled-in-on-recording-methods-methodologies)

## Steps to reproduce:

Fill in a checkbox page and move away from it. Go back via the "Back" link or by entering the previous step's URL.

## What should happen?

The checkboxes should show the values you chose

## What actually happens?

The checkboxes are blank.

This PR fixes the above issue