### PR TITLE
Fix headers and hints

### DIFF
--- a/app/assets/stylesheets/app/session_preview.scss
+++ b/app/assets/stylesheets/app/session_preview.scss
@@ -1,3 +1,4 @@
-.editable, .editable > p {
+.editable,
+.editable > p {
   background: $highlight-background-colour;
 }

--- a/app/assets/stylesheets/barnardos/_checkbox.scss
+++ b/app/assets/stylesheets/barnardos/_checkbox.scss
@@ -80,6 +80,15 @@ $outer-ring: $inner-ring + ($ring-size * 3);
   cursor: not-allowed;
 }
 
+.checkbox-group__hint {
+  color: $secondary-text;
+  display: block;
+  font-family: $font-family;
+  font-size: $base-font-size;
+  line-height: 24px;
+  margin-top: $gutter / 2;
+}
+
 .checkbox-group__error {
   color: $error-colour;
   margin: ($gutter / 2);

--- a/app/assets/stylesheets/barnardos/_radio.scss
+++ b/app/assets/stylesheets/barnardos/_radio.scss
@@ -81,6 +81,15 @@ $outer-ring: $inner-ring + ($ring-size * 3);
   cursor: not-allowed;
 }
 
+.radio-group__hint {
+  color: $secondary-text;
+  display: block;
+  font-family: $font-family;
+  font-size: $base-font-size;
+  line-height: 24px;
+  margin-top: $gutter / 2;
+}
+
 .radio-group__error {
   color: $error-colour;
   margin: ($gutter / 2);

--- a/app/assets/stylesheets/barnardos/_textarea.scss
+++ b/app/assets/stylesheets/barnardos/_textarea.scss
@@ -62,6 +62,9 @@
 .textarea__hint {
   color: $secondary-text;
   display: block;
+  font-family: $font-family;
+  font-size: $base-font-size;
+  line-height: 24px;
   margin-top: $gutter / 2;
 }
 

--- a/app/assets/stylesheets/barnardos/_textfield.scss
+++ b/app/assets/stylesheets/barnardos/_textfield.scss
@@ -49,6 +49,8 @@
   color: $secondary-text;
   display: block;
   margin-top: $gutter / 2;
+  font-size: $base-font-size;
+  line-height: 24px;
 }
 
 .textfield__error {

--- a/app/views/gallery/index.html.erb
+++ b/app/views/gallery/index.html.erb
@@ -1,3 +1,22 @@
+<style>
+  code {
+    font-family: monospace;
+    font-size: 80%;
+  }
+
+  .example {
+    margin-bottom: 1em;
+    padding: 0;
+  }
+
+  .example code {
+    display: block;
+    white-space: pre;
+    line-height: 1.2em;
+    color: #555;
+  }
+</style>
+
 <h1 class="title">Title</h1>
 <h2 class="subtitle-large">Subtitle Large</h2>
 <h3 class="subtitle-medium">Subtitle Medium</h3>
@@ -21,13 +40,124 @@
 
 <%= form_tag do %>
 
-  <%= labelled_text_field_tag :participant_name,
-                              'What is the name of the research participant?',
-                              label_options: { hint: 'Full name' } %>
+  <h1 class="title"><code>Barnardos::ActionView::FormHelpers</code></h1>
+  <h2 class="title"><code>labelled_text_field_tag</code></h2>
 
-  <%= labelled_text_field_tag :participant_login,
-                              'What is the login of the research participant?',
-                              label_options: { hint: 'Full name' },
-                              error: 'Test error message' %>
+  <h3 class="subtitle-large">With hint</h3>
+  <div class="example">
+    <code>
+<%%= labelled_text_field_tag :participant_name,
+      'What is the name of the research participant?',
+      label_options: { hint: 'Full name' } %>
+    </code>
+
+    <%= labelled_text_field_tag :participant_name,
+        'What is the name of the research participant?',
+        label_options: { hint: 'Full name' } %>
+  </div>
+
+
+  <h3 class="subtitle-large">With error</h3>
+  <div class="example">
+    <code>
+<%%= labelled_text_field_tag :participant_login,
+      'What is the login of the research participant?',
+      label_options: { hint: 'Full name' },
+      error: 'Test error message' %>
+    </code>
+
+    <%= labelled_text_field_tag :participant_login,
+          'What is the login of the research participant?',
+          label_options: { hint: 'Full name' },
+          error: 'Test error message' %>
+  </div>
+
+  <h3 class="subtitle-large">With a hint and label class of <code>subtitle-large</code></h3>
+  <div class="example">
+    <code>
+<%%= labelled_text_field_tag :participant_login,
+      'What is the login of the research participant?',
+      label_options: { hint: 'Some hint', class: 'subtitle-large' } %>
+    </code>
+
+    <%= labelled_text_field_tag :participant_login,
+          'What is the login of the research participant?',
+          label_options: { hint: 'Some hint', class: 'subtitle-large' } %>
+  </div>
+
+
+  <h2 class="title"><code>labelled_text_area_tag</code></h2>
+
+  <h3 class="subtitle-large">With error</h3>
+  <div class="example">
+    <code>
+<%%= labelled_text_area_tag(
+      :focus,
+      'What is the focus of your research project?',
+      label_options: {
+          hint: 'Use simple language to explain what you are researching '\
+              'and why you are doing it',
+          class: 'subtitle-large'
+      }
+  )
+%>
+    </code>
+    <%= labelled_text_area_tag(
+          :focus,
+          'What is the focus of your research project?',
+          label_options: {
+              hint: 'Use simple language to explain what you are researching '\
+                  'and why you are doing it',
+              class: 'subtitle-large'
+          }
+      )
+    %>
+  </div>
+
+  <h2 class="title"><code>checkbox_group_vertical</code></h2>
+
+  <h3 class="subtitle-large">With hint</h3>
+  <div class="example">
+    <code>
+<%%= checkbox_group_vertical(
+        'methodologies[]',
+        'What research methodologies will you be using?',
+        Methodologies::NAME_VALUES,
+        legend_options: { class: 'subtitle-large', hint: 'A sniff of a hint' }
+      )
+%>
+    </code>
+    <%= checkbox_group_vertical(
+            'methodologies[]',
+            'What research methodologies will you be using?',
+            Methodologies::NAME_VALUES,
+            legend_options: { class: 'subtitle-large', hint: 'A sniff of a hint' }
+        )
+    %>
+  </div>
+
+  <h2 class="title"><code>radio_group_vertical</code></h2>
+
+  <h3 class="subtitle-large">With hint</h3>
+  <div class="example">
+    <code>
+<%%=
+  radio_group_vertical :age,
+      'What is the age of the research participant?',
+      Age::NAME_VALUES,
+      @research_session.age,
+      legend_options: { class: 'subtitle-large' }
+%>
+    </code>
+    <%=
+      radio_group_vertical :age,
+          'What is the age of the research participant?',
+          Age::NAME_VALUES,
+          legend_options: { class: 'subtitle-large', hint: 'A sniff of a hint' }
+    %>
+  </div>
+
+
+
 
 <% end %>

--- a/app/views/research_sessions/focus.html.erb
+++ b/app/views/research_sessions/focus.html.erb
@@ -1,7 +1,7 @@
 <%= render 'back_link' %>
 <div class="main-content">
   <%= render 'error_summary' %>
-  <h1 class="visually-hidden">Research Focus</h2>
+  <h1 class="visually-hidden">Research Focus</h1>
   <%= form_for @research_session, url: wizard_path do %>
       <%= labelled_text_area_tag(
             :focus,

--- a/app/views/research_sessions/focus.html.erb
+++ b/app/views/research_sessions/focus.html.erb
@@ -8,10 +8,10 @@
             'What is the focus of your research project?',
             @research_session.focus,
             label_options: {
-                hint: 'Use simple language to explain what you are researching '\
-                      'and why you are doing it'
-            },
-            label_options: { class: 'subtitle-large' }
+              hint: 'Use simple language to explain what you are researching '\
+                    'and why you are doing it',
+              class: 'subtitle-large'
+            }
           )
       %>
 

--- a/app/views/research_sessions/methodologies.html.erb
+++ b/app/views/research_sessions/methodologies.html.erb
@@ -1,7 +1,7 @@
 <%= render 'back_link' %>
 <div class="main-content">
   <%= render 'error_summary' %>
-  <h1 class="visually-hidden">Methodologies</h2>
+  <h1 class="visually-hidden">Methodologies</h1>
   <%= form_for @research_session, url: wizard_path do %>
       <%= checkbox_group_vertical(
             'methodologies[]',

--- a/app/views/research_sessions/recording.html.erb
+++ b/app/views/research_sessions/recording.html.erb
@@ -1,7 +1,7 @@
 <%= render 'back_link' %>
 <div class="main-content">
   <%= render 'error_summary' %>
-  <h1 class="visually-hidden">Recording Methods</h2>
+  <h1 class="visually-hidden">Recording Methods</h1>
   <%= form_for @research_session, url: wizard_path do %>
       <%= checkbox_group_vertical(
             'recording_methods[]',


### PR DESCRIPTION
While making #45, we noticed a couple of problems:

1. A few headers had the wrong closing tags 
2. Some options to a helper were duplicated and causing a "last in wins" scenario. Fixing this necessitated an extra CSS change.