### PR TITLE
Warn on exit

### DIFF
--- a/app/javascript/lib/exit_warn.js
+++ b/app/javascript/lib/exit_warn.js
@@ -1,0 +1,28 @@
+let changed = false
+const form = document.querySelector('form')
+
+function beforeUnload (event) {
+  const message = 'You have unsaved changes'
+
+  event = event || window.event
+  // For IE and Firefox
+  if (event) {
+    event.returnValue = message
+  }
+
+  // For Safari
+  return message
+}
+
+if (form) {
+  form.addEventListener('submit', () => {
+    window.removeEventListener('beforeunload', beforeUnload)
+  })
+
+  form.addEventListener('change', () => {
+    if (!changed) {
+      changed = true
+      window.addEventListener('beforeunload', beforeUnload)
+    }
+  })
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,6 +7,7 @@
 // To reference this file, add <%= javascript_pack_tag 'application' %> to the appropriate
 // layout file, like app/views/layouts/application.html.erb
 
+require('../lib/exit_warn')
 const HighlightControl = require('../components/highlightcontrol')
 
 HighlightControl.init()


### PR DESCRIPTION
Most browsers warn the user that they are leaving a page and have made changes to a form. This small polyfill listens for form changes and adds an event to warn the user if they try to leave the page, unless they submit the form in which case it removes the event handler that does that.

The reason the event is added and taken away is that if we just try to return false or something from that event handler it puts that on the screen. The easiest way to handle things is remove the even handler altogether when you submit a page as it's no longer needed.