### PR TITLE
Linter js should fail build

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 public/
 manifest.js
+app/javascript/vendor/**/*.js

--- a/lib/tasks/npm.rake
+++ b/lib/tasks/npm.rake
@@ -1,4 +1,5 @@
 require 'json'
+require 'English'
 
 # Wrap the npm commands in package.json/scripts
 # in their own namespaced tasks
@@ -7,6 +8,11 @@ namespace :npm do
 
   package_json['scripts'].each do |name, _command|
     desc "#{name} from package.json/scripts"
-    task(name) { puts `npm run #{name}` }
+    task(name) do
+      unless system("npm run #{name}")
+        STDERR.puts "npm run #{name} failed with exit code #{$CHILD_STATUS.exitstatus}"
+        exit($CHILD_STATUS.exitstatus)
+      end
+    end
   end
 end


### PR DESCRIPTION
# [JS linters aren't failing the build](https://trello.com/c/876VQvBc/105-split-out-bugfix-pr-for-headings-and-hints)

`hotjar.js` produced 37 errors, but didn't fail the build. Although we'd want to exclude hotjar's script from our linting, it's been a useful canary.

Make sure tasks under `rake npm:*` bubble their exit code correctly rather than masking problems.