### PR TITLE
Fix compatibility with IE9-11 js

### DIFF
--- a/app/javascript/components/highlightcontrol.js
+++ b/app/javascript/components/highlightcontrol.js
@@ -29,9 +29,11 @@ class HighlightControl {
   }
 
   static init (container = document) {
-    container.querySelectorAll(`.${wrapperClass}`).forEach((element) => {
-      new HighlightControl(element)
-    })
+    Array
+      .from(container.querySelectorAll(`.${wrapperClass}`))
+      .forEach((element) => {
+        new HighlightControl(element)
+      })
   }
 }
 


### PR DESCRIPTION
IE does not allow iteration of nodelist.
Convert nodelist to array to allow iteration.