### PR TITLE
Add ruby version to Gemfile for Heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 source 'http://rubygems.org'
 
+ruby_version = File.read('.ruby-version').chomp
+ruby ruby_version
+
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
   "https://github.com/#{repo_name}.git"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,5 +255,8 @@ DEPENDENCIES
   webpacker (~> 2.0)
   wicked (~> 1.3.2)
 
+RUBY VERSION
+   ruby 2.4.1p111
+
 BUNDLED WITH
-   1.15.1
+   1.15.3


### PR DESCRIPTION
Heroku doesn't get its ruby version from .ruby-version. It relies
on the Gemfile. Set that the same by reading the .ruby-version file
here.