### PR TITLE
Add a link to the current release SHA

### DIFF
--- a/app/assets/stylesheets/barnardos/_page.scss
+++ b/app/assets/stylesheets/barnardos/_page.scss
@@ -27,6 +27,18 @@
   margin-right: $gutter;
 }
 
+#global-header__release {
+  width: auto;
+  max-width: 50em;
+  display: block;
+
+  > label {
+    font-size: 80%;
+    float: right;
+    margin-right: $gutter;
+  }
+}
+
 #global-header-bar {
   background: $primary-colour;
   height: $gutter / 2;

--- a/app/assets/stylesheets/barnardos/_page.scss
+++ b/app/assets/stylesheets/barnardos/_page.scss
@@ -27,18 +27,6 @@
   margin-right: $gutter;
 }
 
-#global-header__release {
-  width: auto;
-  max-width: 50em;
-  display: block;
-
-  > label {
-    font-size: 80%;
-    float: right;
-    margin-right: $gutter;
-  }
-}
-
 #global-header-bar {
   background: $primary-colour;
   height: $gutter / 2;
@@ -49,6 +37,22 @@
   padding: 0 $gutter;
   width: 100%;
   max-width: $max-container-width;
+}
+
+#global-footer__release {
+  position: absolute;
+  background-color: white;
+  right: 0;
+  bottom: 0;
+  border-top: 1px solid silver;
+  border-left: 1px solid silver;
+  border-top-left-radius: 3px;
+  padding: 3px ($gutter / 2) 5px ($gutter / 2);
+
+  > label {
+    font-size: 80%;
+    color: $black;
+  }
 }
 
 #content {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,10 @@
 module ApplicationHelper
+  COMMIT_STEM = 'https://github.com/barnardos/consent-form-builder-rails/commit/'.freeze
+
+  def link_to_current_sha(sha_getter = -> { `git rev-parse HEAD` })
+    sha = ENV['HEROKU_SLUG_COMMIT'] || sha_getter.call
+    return 'unavailable' if sha.nil?
+
+    link_to sha[0..7], COMMIT_STEM + sha
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,6 +25,10 @@
     <%= image_tag 'barnardos-logo.svg', alt: 'Barnardos logo' %>
   </div>
   <div id="global-header__menu"></div>
+
+  <div id="global-header__release">
+    <label>Release <%= link_to_current_sha %></label>
+  </div>
 </header>
 
 <div id="global-header-bar">
@@ -36,6 +40,7 @@
     <%= yield %>
   </div>
 </main>
+
 <%= javascript_pack_tag 'application' %>
 </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,10 +25,6 @@
     <%= image_tag 'barnardos-logo.svg', alt: 'Barnardos logo' %>
   </div>
   <div id="global-header__menu"></div>
-
-  <div id="global-header__release">
-    <label>Release <%= link_to_current_sha %></label>
-  </div>
 </header>
 
 <div id="global-header-bar">
@@ -42,6 +38,11 @@
 </main>
 
 <%= javascript_pack_tag 'application' %>
+
+<footer id="global-footer__release">
+  <label>Release <%= link_to_current_sha %></label>
+</footer>
+
 </body>
 </html>
 

--- a/features/aids_for_devops.feature
+++ b/features/aids_for_devops.feature
@@ -1,0 +1,18 @@
+Feature:
+  As a person managing an issue with the app
+  I want to see a link to our current release
+  So that I can know whether what I'm testing fixes my issue
+
+  Scenario: We are in production
+    Given we are in production
+    When I visit the home page
+    Then I should see a short-SHA link to the current version
+    When I start to create a form
+    Then I should still see a short-SHA link to the current version
+
+  Scenario: We are in development
+    Given we are in development
+    When I visit the home page
+    Then I should see a short-SHA link to the current version
+    When I start to create a form
+    Then I should still see a short-SHA link to the current version

--- a/features/step_definitions/aids_for_devops_steps.rb
+++ b/features/step_definitions/aids_for_devops_steps.rb
@@ -1,0 +1,31 @@
+PRODUCTION_COMMIT_SHA = '267e26642e1f6abab769f01d8295643cb789f852'.freeze
+DEVELOPMENT_COMMIT_SHA = `git rev-parse HEAD`.freeze
+
+Given(/^we are in production$/) do
+  @commit_sha = PRODUCTION_COMMIT_SHA
+  ENV['HEROKU_SLUG_COMMIT'] = @commit_sha
+end
+
+Given(/^we are in development$/) do
+  @commit_sha = DEVELOPMENT_COMMIT_SHA
+  ENV['HEROKU_SLUG_COMMIT'] = nil
+end
+
+Then(/^I should (?:still )?see a short-SHA link to the current version$/) do
+  within 'header' do
+    expect(page).to have_tag(
+      'a', text: @commit_sha[0..7],
+           href: 'https://github.com/barnardos/consent-form-builder-rails/'\
+                 'commit/169cea1b98b91af691ee5f029e3afcc9dea9408b',
+           class: 'current-version'
+    )
+  end
+end
+
+When(/^I visit the home page$/) do
+  visit '/'
+end
+
+When(/^I start to create a form$/) do
+  click_link 'Create new form'
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  include RSpecHtmlMatchers
+
+  describe '#link_to_current_sha' do
+    let(:sha_getter) { -> { `git rev-parse HEAD` } }
+    subject(:link) { helper.link_to_current_sha(sha_getter) }
+
+    context 'in development' do
+      let(:current_head_sha) { `git rev-parse HEAD` }
+
+      before { ENV['HEROKU_SLUG_COMMIT'] = nil }
+
+      it 'is the current HEAD SHA' do
+        expect(link).to have_tag(
+          'a',
+          text: current_head_sha[0..7],
+          href: "#{ApplicationHelper::COMMIT_STEM}#{current_head_sha}"
+        )
+      end
+    end
+
+    context 'in production' do
+      let(:heroku_slug_commit) { '169cea1b98b91af691ee5f029e3afcc9dea9408b' }
+
+      before { ENV['HEROKU_SLUG_COMMIT'] = heroku_slug_commit }
+      after  { ENV['HEROKU_SLUG_COMMIT'] = nil }
+
+      it 'is from the HEROKU_SLUG_COMMIT var' do
+        expect(link).to have_tag(
+          'a',
+          text: heroku_slug_commit[0..7],
+          href: "#{ApplicationHelper::COMMIT_STEM}#{heroku_slug_commit}"
+        )
+      end
+    end
+
+    context 'in some other env that does not have a repo or an env var' do
+      let(:sha_getter) { -> { nil } }
+      before { ENV['HEROKU_SLUG_COMMIT'] = nil }
+
+      it { is_expected.to eql('unavailable') }
+    end
+  end
+end


### PR DESCRIPTION
- Adds a link to the current `HEAD` commit on Github in a minimal footer
- Dependent on github links
- Dependent on presence of `HEROKU_SLUG_COMMIT` if in production
- Will show 'Release: unavailable' for any environment without
  `HEROKU_SLUG_COMMIT` or a git repo with a `HEAD`

We can do better than this, but this at least gives PM and DM an idea
of what's live. We can get to reasonable release naming and a changelog
next – this ticket is "minimal what's live"

<img width="283" alt="screen shot 2017-08-10 at 12 10 53" src="https://user-images.githubusercontent.com/194511/29168043-0cd94328-7dc5-11e7-98a0-41bd86daf572.png">
