### PR TITLE
Add 'other' checkboxes

### DIFF
--- a/app/models/methodologies.rb
+++ b/app/models/methodologies.rb
@@ -6,7 +6,8 @@ class Methodologies
     focusgroup:  'Focus group',
     codesign:    'Codesign workshop',
     observation: 'Observation/field study',
-    diary:       'Diary study'
+    diary:       'Diary study',
+    other:       'Other'
   }
 
   def self.allowed_values

--- a/app/models/recording_methods.rb
+++ b/app/models/recording_methods.rb
@@ -6,7 +6,8 @@ class RecordingMethods
     workshop: 'Workshop outputs',
     photo:    'Photographs',
     user:     'User generated content',
-    screen:   'Screen recording'
+    screen:   'Screen recording',
+    other:    'Other'
   }
 
   def self.allowed_values

--- a/app/models/research_session.rb
+++ b/app/models/research_session.rb
@@ -4,6 +4,16 @@ class ResearchSession < ApplicationRecord
   validates :methodologies,
             has_at_least_one: { of: Methodologies.allowed_values },
             if: -> (session) { session.reached_step?(:methodologies) }
+  validates :other_methodology, presence: true,
+            if: lambda { |session|
+              session.reached_step?(:methodologies) &&
+                session.methodologies&.any? { |item| item.to_s == 'other' }
+            }
+  validates :other_recording_method, presence: true,
+            if: lambda { |session|
+              session.reached_step?(:recording) &&
+                session.recording_methods&.any? { |item| item.to_s == 'other' }
+            }
   validates :recording_methods,
             has_at_least_one: { of: RecordingMethods.allowed_values },
             if: -> (session) { session.reached_step?(:recording) }

--- a/app/models/research_session/steps.rb
+++ b/app/models/research_session/steps.rb
@@ -6,8 +6,8 @@ class ResearchSession
 
     PARAMS = ActiveSupport::OrderedHash[{
       age:           [:age],
-      methodologies: [methodologies: []],
-      recording:     [recording_methods: []],
+      methodologies: [:other_methodology, methodologies: []],
+      recording:     [:other_recording_method, recording_methods: []],
       focus:         [:focus],
       researcher:    [:researcher_name, :researcher_phone,
                       :researcher_email, :researcher_other_name],
@@ -30,11 +30,15 @@ class ResearchSession
       @attrs_to_steps ||=
         PARAMS.each_with_object({}) do |kv, params_to_steps|
           step, params = *kv
-          case params.first
-          when Symbol
-            params.each { |param| params_to_steps[param] = step }
-          when Hash
-            params.first.keys.each { |param| params_to_steps[param] = step }
+          params.each do |param|
+            case param
+            when Symbol
+              params_to_steps[param] = step
+            when Hash
+              param.keys.each do |array_param|
+                params_to_steps[array_param] = step
+              end
+            end
           end
         end
       @attrs_to_steps.fetch(attr)

--- a/app/presenters/research_session_presenter.rb
+++ b/app/presenters/research_session_presenter.rb
@@ -1,19 +1,28 @@
 class ResearchSessionPresenter < Struct.new(:research_session)
   delegate :age, :focus, :researcher_name, :researcher_other_name,
            :researcher_email, :researcher_phone, :unable_to_consent?,
+           :other_methodology, :other_recording_method,
            to: :research_session
 
   def methodology_list
     paras = research_session.methodologies.map do |methodology|
-      i18n_key = "age.#{age}.#{methodology}"
-      "<p class='highlight'>#{I18n.t(i18n_key)}</p>"
+      translation = if methodology.to_s == 'other'
+                      other_methodology
+                    else
+                      I18n.t("age.#{age}.#{methodology}")
+                    end
+      "<p class='highlight'>#{translation}</p>"
     end
     paras.join("\n").html_safe
   end
 
   def recording_methods_list
     lowercase_words = research_session.recording_methods.map do |method|
-      RecordingMethods::NAME_VALUES.fetch(method.to_sym).downcase
+      if method.to_s == 'other'
+        other_recording_method
+      else
+        RecordingMethods::NAME_VALUES.fetch(method.to_sym).downcase
+      end
     end
     lowercase_words.to_sentence
   end

--- a/app/views/research_sessions/methodologies.html.erb
+++ b/app/views/research_sessions/methodologies.html.erb
@@ -12,6 +12,13 @@
           )
       %>
 
+      <%= labelled_text_area_tag(
+            :other_methodology,
+            'What is the other methodology?',
+            @research_session.other_methodology
+          )
+      %>
+
       <%= render 'ok_cancel' %>
   <% end %>
 </div>

--- a/app/views/research_sessions/methodologies.html.erb
+++ b/app/views/research_sessions/methodologies.html.erb
@@ -12,7 +12,7 @@
           )
       %>
 
-      <%= labelled_text_area_tag(
+      <%= labelled_text_field_tag(
             :other_methodology,
             'What is the other methodology?',
             @research_session.other_methodology

--- a/app/views/research_sessions/recording.html.erb
+++ b/app/views/research_sessions/recording.html.erb
@@ -12,7 +12,7 @@
           )
       %>
 
-      <%= labelled_text_area_tag(
+      <%= labelled_text_field_tag(
             :other_recording_method,
             'What is the other recording method?',
             @research_session.other_recording_method

--- a/app/views/research_sessions/recording.html.erb
+++ b/app/views/research_sessions/recording.html.erb
@@ -12,6 +12,13 @@
           )
       %>
 
+      <%= labelled_text_area_tag(
+            :other_recording_method,
+            'What is the other recording method?',
+            @research_session.other_recording_method
+          )
+      %>
+
       <%= render 'ok_cancel' %>
   <% end %>
 </div>

--- a/db/migrate/20170809140248_add_other_methodology_and_other_recording_method.rb
+++ b/db/migrate/20170809140248_add_other_methodology_and_other_recording_method.rb
@@ -1,0 +1,6 @@
+class AddOtherMethodologyAndOtherRecordingMethod < ActiveRecord::Migration[5.1]
+  def change
+    add_column :research_sessions, :other_methodology, :string
+    add_column :research_sessions, :other_recording_method, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170720083727) do
+ActiveRecord::Schema.define(version: 20170809140248) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,8 @@ ActiveRecord::Schema.define(version: 20170720083727) do
     t.decimal "incentive_value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "other_methodology"
+    t.string "other_recording_method"
     t.index ["status"], name: "index_research_sessions_on_status"
   end
 

--- a/features/printed_consent_forms.feature
+++ b/features/printed_consent_forms.feature
@@ -18,11 +18,9 @@ Feature:
 
   Scenario: I am using a research methodology or recording method that is not in the list
     Given I have arrived at the methodologies step
-    Then I should see checkboxes for all the methodologies
     And I should see an 'Other' checkbox for methodologies with a space to fill this in
     When I provide an 'Other' methodology
     And I click the continue button
-    Then I should see checkboxes for all the recording methods
     And I should see an 'Other' checkbox for recording methods with a space to fill this in
     When I provide an 'Other' recording method
     And I click the continue button

--- a/features/printed_consent_forms.feature
+++ b/features/printed_consent_forms.feature
@@ -18,14 +18,9 @@ Feature:
 
   Scenario: I am using a research methodology or recording method that is not in the list
     Given I have arrived at the methodologies step
-    And I should see an 'Other' checkbox for methodologies with a space to fill this in
     When I provide an 'Other' methodology
-    And I click the continue button
-    And I should see an 'Other' checkbox for recording methods with a space to fill this in
-    When I provide an 'Other' recording method
-    And I click the continue button
+    And I provide an 'Other' recording method
     And I fill in the remaining steps
     Then I should see the session review page
     And I should see my 'Other' methodology
     And I should see my 'Other' recording method
-

--- a/features/printed_consent_forms.feature
+++ b/features/printed_consent_forms.feature
@@ -11,10 +11,23 @@ Feature:
     And I should see an age-specific text block for each research methodology selected
     And I should see a humanised indication of recording methods used
     And I should see links back to edit things that I provided
-    When I click continue
+    When I click the continue link
     Then I should see the age-appropriate consent form preview
     And it should have a place for name, signature and date
     And I should see a way to print it
 
-
+  Scenario: I am using a research methodology or recording method that is not in the list
+    Given I have arrived at the methodologies step
+    Then I should see checkboxes for all the methodologies
+    And I should see an 'Other' checkbox for methodologies with a space to fill this in
+    When I provide an 'Other' methodology
+    And I click the continue button
+    Then I should see checkboxes for all the recording methods
+    And I should see an 'Other' checkbox for recording methods with a space to fill this in
+    When I provide an 'Other' recording method
+    And I click the continue button
+    And I fill in the remaining steps
+    Then I should see the session review page
+    And I should see my 'Other' methodology
+    And I should see my 'Other' recording method
 

--- a/features/step_definitions/question_steps.rb
+++ b/features/step_definitions/question_steps.rb
@@ -57,14 +57,6 @@ Given(/^I have arrived at the methodologies step$/) do
   click_button 'Continue'
 end
 
-Then(/^I should see checkboxes for all the methodologies$/) do
-  Methodologies::NAME_VALUES.each_pair do |name, description|
-    input_id = "methodologies[]-#{name}"
-    expect(page).to have_tag('label', text: description, with: { for: input_id })
-    expect(page).to have_tag('input', with: { id: input_id })
-  end
-end
-
 And(/^I should see an 'Other' checkbox for (.*) with a space to fill this in$/) do |attr|
   attr = attr.downcase.tr(' ', '_')
   expect(page).to have_tag('label', with: { for: "#{attr}[]-other" })
@@ -84,14 +76,6 @@ When(/^I provide an 'Other' recording method$/) do
 
   @other_recording_method = 'A.N. Other Recording Method'
   fill_in 'What is the other recording method?', with: @other_recording_method
-end
-
-Then(/^I should see checkboxes for all the recording methods$/) do
-  RecordingMethods::NAME_VALUES.each_pair do |name, description|
-    input_id = "recording_methods[]-#{name}"
-    expect(page).to have_tag('label', text: description, with: { for: input_id })
-    expect(page).to have_tag('input', with: { id: input_id })
-  end
 end
 
 And(/^I fill in the remaining steps$/) do

--- a/features/step_definitions/question_steps.rb
+++ b/features/step_definitions/question_steps.rb
@@ -49,3 +49,78 @@ end
 Then(/^I should see the session review page$/) do
   step 'I should see confirmation that this is a preview'
 end
+
+Given(/^I have arrived at the methodologies step$/) do
+  visit '/'
+  click_link 'Create new form'
+  choose 'Under 12 years old'
+  click_button 'Continue'
+end
+
+Then(/^I should see checkboxes for all the methodologies$/) do
+  Methodologies::NAME_VALUES.each_pair do |name, description|
+    input_id = "methodologies[]-#{name}"
+    expect(page).to have_tag('label', text: description, with: { for: input_id })
+    expect(page).to have_tag('input', with: { id: input_id })
+  end
+end
+
+And(/^I should see an 'Other' checkbox for (.*) with a space to fill this in$/) do |attr|
+  attr = attr.downcase.tr(' ', '_')
+  expect(page).to have_tag('label', with: { for: "#{attr}[]-other" })
+  expect(page).to have_tag('input', with: { id: "#{attr}[]-other" })
+  expect(page).to have_tag('input', with: { id: "#{attr}[]-other" })
+end
+
+When(/^I provide an 'Other' methodology$/) do
+  check 'methodologies[]-other'
+
+  @other_methodology = 'A.N. Other Methodology'
+  fill_in 'What is the other methodology?', with: @other_methodology
+end
+
+When(/^I provide an 'Other' recording method$/) do
+  check 'recording_methods[]-other'
+
+  @other_recording_method = 'A.N. Other Recording Method'
+  fill_in 'What is the other recording method?', with: @other_recording_method
+end
+
+Then(/^I should see checkboxes for all the recording methods$/) do
+  RecordingMethods::NAME_VALUES.each_pair do |name, description|
+    input_id = "recording_methods[]-#{name}"
+    expect(page).to have_tag('label', text: description, with: { for: input_id })
+    expect(page).to have_tag('input', with: { id: input_id })
+  end
+end
+
+And(/^I fill in the remaining steps$/) do
+  @focus = <<~TEXT_WITH_DOUBLE_AND_SINGLE_LINEBREAK
+    Fresnel lenses and the under-5s
+    This line break follows a br
+
+    Whereas this becomes its own p
+  TEXT_WITH_DOUBLE_AND_SINGLE_LINEBREAK
+
+  fill_in 'What is the focus of your research project?',
+          with: @focus
+  click_button 'Continue'
+
+  within '[name="first-researcher"]' do
+    fill_in 'Full name', with: 'Rachel Researcher'
+    fill_in 'Telephone number', with: '012345678'
+    fill_in 'Email', with: 'rachel@researcher.com'
+  end
+
+  within '[name="second-researcher"]' do
+    fill_in 'Full name', with: 'Steve Secondresearcher'
+  end
+  click_button 'Continue'
+
+  choose 'incentive-1'
+
+  choose 'payment_type-cash'
+  fill_in 'Incentive value', with: '10.50'
+
+  click_button 'Continue'
+end

--- a/features/step_definitions/question_steps.rb
+++ b/features/step_definitions/question_steps.rb
@@ -64,14 +64,14 @@ And(/^I should see an 'Other' checkbox for (.*) with a space to fill this in$/) 
   expect(page).to have_tag('input', with: { id: "#{attr}[]-other" })
 end
 
-When(/^I provide an 'Other' methodology$/) do
+When(/^I fill in the 'Other' methodology$/) do
   check 'methodologies[]-other'
 
   @other_methodology = 'A.N. Other Methodology'
   fill_in 'What is the other methodology?', with: @other_methodology
 end
 
-When(/^I provide an 'Other' recording method$/) do
+When(/^I fill in the 'Other' recording method$/) do
   check 'recording_methods[]-other'
 
   @other_recording_method = 'A.N. Other Recording Method'
@@ -107,4 +107,16 @@ And(/^I fill in the remaining steps$/) do
   fill_in 'Incentive value', with: '10.50'
 
   click_button 'Continue'
+end
+
+When(/^I provide an 'Other' methodology$/) do
+  step "I should see an 'Other' checkbox for methodologies with a space to fill this in"
+  step "I fill in the 'Other' methodology"
+  step 'I click the continue button'
+end
+
+And(/^I provide an 'Other' recording method$/) do
+  step "I should see an 'Other' checkbox for recording methods with a space to fill this in"
+  step "I fill in the 'Other' recording method"
+  step 'I click the continue button'
 end

--- a/features/step_definitions/session_review_steps.rb
+++ b/features/step_definitions/session_review_steps.rb
@@ -28,6 +28,18 @@ And(/^I should see links back to edit things that I provided$/) do
   end
 end
 
-When(/^I click continue$/) do
+When(/^I click the continue link$/) do
   click_link 'Continue'
+end
+
+When(/^I click the continue button$/) do
+  click_button 'Continue'
+end
+
+Then(/^I should see my 'Other' methodology$/) do
+  expect(page).to have_content(@other_methodology)
+end
+
+And(/^I should see my 'Other' recording method$/) do
+  expect(page).to have_content(@other_recording_method)
 end

--- a/features/support/action_view.rb
+++ b/features/support/action_view.rb
@@ -1,1 +1,3 @@
+require 'action_view'
+
 include ActionView::Helpers::TextHelper

--- a/features/support/rspec_html_matchers.rb
+++ b/features/support/rspec_html_matchers.rb
@@ -1,1 +1,3 @@
+require 'rspec-html-matchers'
+
 World RSpecHtmlMatchers

--- a/spec/models/research_session_spec.rb
+++ b/spec/models/research_session_spec.rb
@@ -73,16 +73,37 @@ RSpec.describe ResearchSession, type: :model do
           session.age = Age.allowed_values.first
         end
 
-        context 'no methods are selected' do
+        context 'no methodologies are selected' do
           it { is_expected.not_to be_valid }
         end
 
-        context 'at least one valid method is selected' do
+        context 'at least one valid methodology is selected' do
           before do
             session.methodologies = [:interview]
             session.save
           end
           it { is_expected.to be_valid }
+        end
+
+        context 'the "other" methodology is selected' do
+          before do
+            session.methodologies = [:other]
+            session.other_methodology = other_methodology
+            session.save
+          end
+
+          context 'other methodology is blank' do
+            let(:other_methodology) { nil }
+            it { is_expected.not_to be_valid }
+            it 'has one error on other_methodology' do
+              expect(session.errors[:other_methodology].length).to eql(1)
+              expect(session.errors[:other_methodology].first).to eql("can't be blank")
+            end
+          end
+          context 'other methodology is supplied' do
+            let(:other_methodology) { 'Another methodology' }
+            it { is_expected.to be_valid }
+          end
         end
       end
 
@@ -104,6 +125,27 @@ RSpec.describe ResearchSession, type: :model do
             session.save
           end
           it { is_expected.to be_valid }
+        end
+
+        context 'the "other" recording methods is selected' do
+          before do
+            session.recording_methods = [:other]
+            session.other_recording_method = other_recording_method
+            session.save
+          end
+
+          context 'other methodology is blank' do
+            let(:other_recording_method) { nil }
+            it { is_expected.not_to be_valid }
+            it 'has one error on other_recording_method' do
+              expect(session.errors[:other_recording_method].length).to eql(1)
+              expect(session.errors[:other_recording_method].first).to eql("can't be blank")
+            end
+          end
+          context 'other methodology is supplied' do
+            let(:other_recording_method) { 'Another methodology' }
+            it { is_expected.to be_valid }
+          end
         end
       end
 

--- a/spec/presenters/research_session_presenter_spec.rb
+++ b/spec/presenters/research_session_presenter_spec.rb
@@ -51,14 +51,26 @@ RSpec.describe ResearchSessionPresenter do
         expect(list).to include('You will be interviewed')
         expect(list).to include('You will be asked')
       end
+
+      context 'the research session contains "other"' do
+        let(:methodologies) { [:interview, :usability, :other] }
+        before { allow(research_session).to receive(:other_methodology).and_return('Reiki') }
+
+        it 'has it all' do
+          expect(list).to include('Reiki')
+        end
+      end
     end
   end
 
   describe '#recording_methods_list' do
+    let(:other_recording_method) { nil }
+
     subject(:list) { presenter.recording_methods_list }
 
     before do
       allow(research_session).to receive(:recording_methods).and_return(recording_methods)
+      allow(research_session).to receive(:other_recording_method).and_return(other_recording_method)
     end
 
     context 'there is one recording method' do
@@ -74,6 +86,12 @@ RSpec.describe ResearchSessionPresenter do
     context 'there are three recording methods' do
       let(:recording_methods) { [:audio, :video, :written] }
       it { is_expected.to eql('audio, video, and written notes') }
+    end
+
+    context 'there are three recording methods and one is "other"' do
+      let(:recording_methods) { [:audio, :video, :other] }
+      let(:other_recording_method) { 'comic books' }
+      it { is_expected.to eql('audio, video, and comic books') }
     end
   end
 end


### PR DESCRIPTION
# [Add 'Other' Option and Editable Text Box](https://trello.com/c/nIkNeTw7/81-5-add-other-option-and-editable-text-box)

## JTBD

_When I am using a methodology or recording method not listed on the page, I want to be able to add my own, so I can provide the correct information on the form._

## Acceptance

- [x] Add 'Other' checkbox option and text field to Methodologies page
- [x] Add 'Other' checkbox option and text field to Recording Methods page
- [x] If you selected "Other", your option appears last in the list on the session preview

### Nice-to-have

- [ ] Only show text field when other checkbox is ticked

*NB* The "Nice to have" is not done – I have one day left before holiday and it's best to spend that clearing the things that are in review rather than starting new work. Also, it's a nice splittable bit of JS, so if you want a separate card, I've [made one](https://trello.com/c/W7HSG0qw/114-hide-other-text-fields-unless-other-selected-on-methodologies-and-recording-methods) in the Inbox.

<img width="646" alt="screen shot 2017-08-09 at 16 54 19" src="https://user-images.githubusercontent.com/194511/29131080-a07dbab6-7d23-11e7-95d8-bf1b2c7bbfe9.png">

