### PR TITLE
Add app.json to support Heroku PR deployment

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,15 @@
+{
+  "name":"consent-form-builder-rails",
+  "scripts":{},
+  "env":{
+    "LANG": { "required": true },
+    "RAILS_LOG_TO_STDOUT": { "required": true },
+    "RAILS_SERVE_STATIC_FILES": { "required": true },
+    "SECRET_KEY_BASE": { "required": true },
+    "RACK_ENV": "development",
+    "RAILS_ENV": "development"
+  },
+  "addons":["heroku-postgresql:hobby-dev"],
+  "buildpacks": [{ "url": "heroku/ruby" }],
+  "formation": {}
+}


### PR DESCRIPTION
Heroku requries an app.json to tell it how to configure PR created instances, this is that app.json