### PR TITLE
Make the footer stick to the viewport

### DIFF
--- a/app/assets/stylesheets/barnardos/_page.scss
+++ b/app/assets/stylesheets/barnardos/_page.scss
@@ -40,7 +40,7 @@
 }
 
 #global-footer__release {
-  position: absolute;
+  position: fixed;
   background-color: white;
   right: 0;
   bottom: 0;


### PR DESCRIPTION
Oops. Only resized my browser, so missed this on scroll. Go with
`position: fixed` rather than `absolute`.

<img width="395" alt="screen shot 2017-08-10 at 12 59 36" src="https://user-images.githubusercontent.com/194511/29169407-d0ee5cca-7dcb-11e7-8768-97556a641b8b.png">
