### PR TITLE
Fix Sass warnings

### DIFF
--- a/app/assets/stylesheets/app/consent_form_preview.scss
+++ b/app/assets/stylesheets/app/consent_form_preview.scss
@@ -18,7 +18,7 @@
 
   .space-for-writing {
     border: 0;
-    border-bottom: 1px solid black;
+    border-bottom: 1px solid $black;
     width: 100%;
   }
 
@@ -26,7 +26,8 @@
     width: 100%;
   }
 
-  &.signature, &.date {
+  &.signature,
+  &.date {
     width: 50%;
   }
 }

--- a/app/assets/stylesheets/barnardos/_page.scss
+++ b/app/assets/stylesheets/barnardos/_page.scss
@@ -41,13 +41,13 @@
 
 #global-footer__release {
   position: fixed;
-  background-color: white;
+  background-color: $white;
   right: 0;
   bottom: 0;
-  border-top: 1px solid silver;
-  border-left: 1px solid silver;
+  border-top: 1px solid $border;
+  border-left: 1px solid $border;
   border-top-left-radius: 3px;
-  padding: 3px ($gutter / 2) 5px ($gutter / 2);
+  padding: 3px ($gutter / 2) 5px;
 
   > label {
     font-size: 80%;


### PR DESCRIPTION
- Stop using colour literals. Use only those in _colours.scss
- Selectors: one per line
- Concise-imify a padding def

Before:

```bash
➜  consent-form-builder-rails git:(master) npm run lint:styles

> myapp@ lint:styles /Users/russ/dev/bdos/consent-form-builder-rails
> sass-lint -c .sass-lint.yml 'app/assets/stylesheets/**/*.scss' -v -q


app/assets/stylesheets/app/consent_form_preview.scss
  21:30  warning  Color 'black' should be written in its hexadecimal form #000000              no-color-keywords
  21:30  warning  Color literals such as 'black' should only be used in variable declarations  no-color-literals
  29:16  warning  Selectors must be placed on new lines                                        single-line-per-selector

app/assets/stylesheets/barnardos/_page.scss
  44:21  warning  Color 'white' should be written in its hexadecimal form #ffffff                                                                  no-color-keywords
  44:21  warning  Color literals such as 'white' should only be used in variable declarations                                                      no-color-literals
  47:25  warning  Color 'silver' should be written in its hexadecimal form #c0c0c0                                                                 no-color-keywords
  47:25  warning  Color literals such as 'silver' should only be used in variable declarations                                                     no-color-literals
  48:26  warning  Color 'silver' should be written in its hexadecimal form #c0c0c0                                                                 no-color-keywords
  48:26  warning  Color literals such as 'silver' should only be used in variable declarations                                                     no-color-literals
  50:12  warning  Property `padding` should be written more concisely as `3px ($gutter / 2) 5px` instead of `3px ($gutter / 2) 5px ($gutter / 2)`  shorthand-values

✖ 10 problems (0 errors, 10 warnings)
```

After:

❇️ 