### PR TITLE
Hide other text field on change

### DIFF
--- a/app/helpers/barnardos/action_view/form_helpers.rb
+++ b/app/helpers/barnardos/action_view/form_helpers.rb
@@ -155,10 +155,16 @@ module Barnardos
               checked = values&.include?(selection_item_value.to_s)
               concat(
                 content_tag(:div, class: 'checkbox-group__choice') do
+                  options = { class: 'checkbox-group__input', id: id }
+
+                  if block_given?
+                    yield selection_item_value, selection_item_text, options
+                  end
+
                   concat(
                     check_box_tag(
                       name, selection_item_value,
-                      checked, class: 'checkbox-group__input', id: id
+                      checked, options
                     )
                   )
                   concat(

--- a/app/javascript/components/hide_this_other_thing.js
+++ b/app/javascript/components/hide_this_other_thing.js
@@ -1,0 +1,37 @@
+const { addClass, removeClass } = require('../lib/element_helpers')
+
+const WRAPPER_DATA = 'data-hide-control'
+const HIDDEN_CLASS = 'visually-hidden'
+
+class HideThisOtherThing {
+  constructor (checkbox, otherThing) {
+    this.checkbox = checkbox
+    this.otherThing = otherThing
+    this.attachEvents()
+  }
+
+  attachEvents () {
+    this.checkbox.addEventListener('change', this.updateOther.bind(this))
+  }
+
+  updateOther () {
+    if (this.checkbox.checked) {
+      removeClass(this.otherThing, HIDDEN_CLASS)
+    } else {
+      addClass(this.otherThing, HIDDEN_CLASS)
+    }
+  }
+
+  static init (container = document) {
+    Array
+      .from(container.querySelectorAll(`[${WRAPPER_DATA}]`))
+      .forEach((element) => {
+        let elementToHide =
+          document.getElementById(element.dataset.hideControl).parentElement
+        let hider = new HideThisOtherThing(element, elementToHide)
+        hider.updateOther()
+      })
+  }
+}
+
+module.exports = HideThisOtherThing

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,9 +7,10 @@
 // To reference this file, add <%= javascript_pack_tag 'application' %> to the appropriate
 // layout file, like app/views/layouts/application.html.erb
 
-require('../lib/exit_warn')
 const HighlightControl = require('../components/highlightcontrol')
-
 HighlightControl.init()
+const HideThisOtherThing = require('../components/hide_this_other_thing')
+HideThisOtherThing.init()
 
+require('../lib/exit_warn')
 require('../vendor/hotjar')

--- a/app/views/research_sessions/methodologies.html.erb
+++ b/app/views/research_sessions/methodologies.html.erb
@@ -9,7 +9,9 @@
             Methodologies::NAME_VALUES,
             @research_session.methodologies,
             legend_options: { class: 'subtitle-large' }
-          )
+          ) do |value, _text, checkbox_options|
+            checkbox_options['data-hide-control'] = :other_methodology if value == :other
+          end
       %>
 
       <%= labelled_text_field_tag(

--- a/app/views/research_sessions/recording.html.erb
+++ b/app/views/research_sessions/recording.html.erb
@@ -9,7 +9,9 @@
             RecordingMethods::NAME_VALUES,
             @research_session.recording_methods,
             legend_options: { class: 'subtitle-large' }
-          )
+          ) do |value, _text, checkbox_options|
+            checkbox_options['data-hide-control'] = :other_recording_method if value == :other
+          end
       %>
 
       <%= labelled_text_field_tag(

--- a/spec/helpers/barnardos/checkbox_helper_spec.rb
+++ b/spec/helpers/barnardos/checkbox_helper_spec.rb
@@ -106,7 +106,8 @@ RSpec.describe Barnardos::ActionView::FormHelpers, :type => :helper do
 
         it 'has changed the thing we asked it to' do
           expect(rendered).to have_tag(
-            'input.checkbox-group__input', with: { 'data-some-value' => 'foo' })
+            'input.checkbox-group__input', with: { id: 'age-one', 'data-some-value' => 'foo' }
+          )
         end
       end
     end

--- a/spec/helpers/barnardos/checkbox_helper_spec.rb
+++ b/spec/helpers/barnardos/checkbox_helper_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Barnardos::ActionView::FormHelpers, :type => :helper do
     let(:legend)          { 'My legend' }
     let(:legend_options)  { {} }
     let(:values)          { ['one'] }
+    let(:block)           { nil }
 
     let(:selection_options) do
       {
@@ -35,7 +36,7 @@ RSpec.describe Barnardos::ActionView::FormHelpers, :type => :helper do
                                      legend,
                                      selection_options,
                                      values,
-                                     legend_options: legend_options)
+                                     legend_options: legend_options, &block)
     end
 
     context 'an empty enumerable is given' do
@@ -95,6 +96,19 @@ RSpec.describe Barnardos::ActionView::FormHelpers, :type => :helper do
       end
 
       it_behaves_like 'it has correctly classed and labelled input'
+
+      context 'a block is given' do
+        let(:block) do
+          proc do |value, _text, options|
+            options['data-some-value'] = 'foo' if value == 'one'
+          end
+        end
+
+        it 'has changed the thing we asked it to' do
+          expect(rendered).to have_tag(
+            'input.checkbox-group__input', with: { 'data-some-value' => 'foo' })
+        end
+      end
     end
 
     context 'a legend with optional class specified' do


### PR DESCRIPTION
# [Hide "other" text fields unless "other" selected on methodologies and recording methods](https://trello.com/c/W7HSG0qw/114-hide-other-text-fields-unless-other-selected-on-methodologies-and-recording-methods)

**Warning**: this should probably be considered WIP, because there are no tests for the
`HideThisOtherThing` component (I ran out of time and I'm not sufficiently used to test-first in JS, yet).

However, it might serve as a time-saver for @ztolley tomorrow/next week.

Use a new `HideThisOtherThing` component, that is set up in `HideThisOtherThing.init()`, wherein elements with the `data-hide-control` attribute set to the ID of a participating checkbox will hide (via `.visually-hidden`) that checkbox's parent div on `change` if the checkbox is not `checked` and show it if it is.

## [App for PR 61](https://consent-form-builder-sta-pr-61.herokuapp.com/)

Now you see it,

<img width="448" alt="screen shot 2017-08-10 at 18 32 35" src="https://user-images.githubusercontent.com/194511/29183391-622e5b3a-7dfa-11e7-8515-eeb0eb5a3c03.png">

Now you don't

<img width="472" alt="screen shot 2017-08-10 at 18 32 28" src="https://user-images.githubusercontent.com/194511/29183374-5404cb98-7dfa-11e7-9634-95a229a49b14.png">


