### PR TITLE
Fix missing support for text_options in textrea

### DIFF
--- a/app/helpers/barnardos/action_view/form_helpers.rb
+++ b/app/helpers/barnardos/action_view/form_helpers.rb
@@ -58,8 +58,13 @@ module Barnardos
               end
             end
           )
-          concat(text_area_tag(name, value, class: 'textarea__input js-highlight-control__input',
-                                            rows: '4'))
+
+          textarea_options = text_options.reverse_merge(
+            class: 'textarea__input js-highlight-control__input',
+            rows: '4'
+          )
+
+          concat(text_area_tag(name, value, textarea_options))
           concat(content_tag(:div, error, class: 'textarea__error')) if error
         end
       end

--- a/spec/helpers/barnardos/text_area_helper_spec.rb
+++ b/spec/helpers/barnardos/text_area_helper_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Barnardos::ActionView::FormHelpers, :type => :helper do
     let(:label) { 'Describe the thing' }
     let(:value) { 'Some description text' }
     let(:label_options) { {} }
+    let(:text_options) { {} }
     let(:error) {}
 
     subject(:rendered) do
@@ -25,7 +26,8 @@ RSpec.describe Barnardos::ActionView::FormHelpers, :type => :helper do
                                     label,
                                     value,
                                     error: error,
-                                    label_options: label_options)
+                                    label_options: label_options,
+                                    text_options: text_options)
     end
 
     context 'with a name and a label parameter' do
@@ -82,6 +84,14 @@ RSpec.describe Barnardos::ActionView::FormHelpers, :type => :helper do
         expect(rendered).to have_tag(
           'div.textarea.has-error > div.textarea__error', text: 'Error message'
         )
+      end
+    end
+
+    context 'with a placeholder' do
+      let(:text_options) { { placeholder: 'test placeholder' } }
+
+      it 'should add a placeholder if provided' do
+        expect(rendered).to have_tag('textarea[placeholder="test placeholder"].textarea__input')
       end
     end
   end


### PR DESCRIPTION
The labelled text are tag did not use the text options passed to it, so it was not possible to set options such as placeholder. This has been corrected.