### PR TITLE
Prefer #humanize/inflections over translations

### DIFF
--- a/app/views/research_sessions/_progress.html.erb
+++ b/app/views/research_sessions/_progress.html.erb
@@ -25,9 +25,9 @@
           <%= 'is-active' if this_step == step %>">
         <span class="progress__stage-title">
           <% if this_step != step and @research_session and @research_session.reached_step?(this_step) %>
-            <%= link_to t(this_step), question_path(this_step) %>
+            <%= link_to this_step.to_s.humanize, question_path(this_step) %>
           <% else %>
-            <%= t(this_step) %>
+            <%= this_step.to_s.humanize %>
           <% end %>
         </span>
       </li>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -2,13 +2,10 @@
 
 # Add new inflection rules using the following format. Inflections
 # are locale specific, and you may define rules for as many different
-# locales as you wish. All of these examples are active by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.plural /^(ox)$/i, '\1en'
-#   inflect.singular /^(ox)en/i, '\1'
-#   inflect.irregular 'person', 'people'
-#   inflect.uncountable %w( fish sheep )
-# end
+# locales as you wish.
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.human 'time_equipment', 'Time / Equipment'
+end
 
 # These inflection rules are supported but not enabled by default:
 # ActiveSupport::Inflector.inflections(:en) do |inflect|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,16 +30,6 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-
-  hello: "Hello world"
-  methodologies: "Methodologies"
-  recording: "Recording"
-  topic: "Topic"
-  purpose: "Purpose"
-  researcher: "Researcher"
-  incentive: "Incentive"
-  age: "Age"
-
   report:
     over18:
       interview: 'You will be interviewed and asked your views regarding the project being researched.'


### PR DESCRIPTION
If we use `I18n.translate`, translations have to exist in `en.yml`,
otherwise errors make it into the markup (see below).
`String#humanize` doesn't have this issue
(but still lets us specify our own translations).

Before, in _progress output (because we didn't have `en.time_equipment`):
```HTML
<a href="/questions/time_equipment">
  <span class="translation_missing"
        title="translation missing: en.time_equipment">
        Time Equipment
  </span>
</a>
```

After, including a `#human` call in `initializers/inflections.rb`:

```HTML
<a href="/questions/time_equipment">Time / equipment</a>
```

Because the rest of the progress titles are conventional, (for example,
`:methodologies.to_s.humanize => 'Methodologies'`) we don't need
special cases for anything else and can remove the obligation to
translate in `en.yml`.