### PR TITLE
Fix empty preview researcher

### DIFF
--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -58,7 +58,7 @@
     With your permission we will record the session using
     <%= edit_link_for(:recording_methods) { @research_session.recording_methods_list } %>.
     Recording the session helps the researcher and other research team members
-    trying to improve the service, asit allows them to review the most useful
+    trying to improve the service, as it allows them to review the most useful
     parts of the session after it hasfinished.
   </p>
 </section>
@@ -81,7 +81,7 @@
     research. <%= edit_link_for(:researcher_name) %> can be contacted by email at
     <%= edit_link_for(:researcher_email) %> or by telephone on <%= edit_link_for(:researcher_phone) %>.</p>
   <p>If you have any questions or concerns about the way in which this research has
-    been conducted then please contactJoelle Bradly at
+    been conducted then please contact Joelle Bradly at
     <a href="mailto:joelle.bradly@barnardos.org.uk">joelle.bradly@barnardos.org.uk</a></p>
 </section>
 <section>

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -41,7 +41,7 @@
   <h3 class="subtitle-small" id="who">Who is doing the research?</h3>
   <p>
     <%= edit_link_for(:researcher_name) %> is the researcher who will be leading the session.
-    <% if @research_session.researcher_other_name %>
+    <% if @research_session.researcher_other_name.present? %>
       <%= edit_link_for(:researcher_name) %>ʼs colleague,
       <%= edit_link_for(:researcher_other_name) %>,
       may join <%= edit_link_for(:researcher_name) %> sometimes to help.


### PR DESCRIPTION
# [BUG: Other researcher is always visible on the preview, even when a second researcher hasn't been entered.](https://trello.com/c/yHJXIH1F/139-bug-other-researcher-is-always-visible-on-the-preview-even-when-a-second-researcher-hasnt-been-entered)

Fix this problem:

<img width="910" alt="screen shot 2017-09-04 at 15 23 50" src="https://user-images.githubusercontent.com/194511/30099774-a2d53188-92de-11e7-81e9-57ca387d6f1e.png">
