### PR TITLE
Disable conditional subfields, don't clear value

### DIFF
--- a/app/javascript/components/conditional_subfields.js
+++ b/app/javascript/components/conditional_subfields.js
@@ -139,18 +139,15 @@ const ConditionalSubfields = {
     subField.setAttribute('aria-expanded', isVisible)
     subField.setAttribute('aria-hidden', !isVisible)
 
-    if (!isVisible && !subField.getAttribute('data-persist-values')) {
-      const children = subField.querySelectorAll('input, select, checkbox, textarea')
+    const children = subField.querySelectorAll('input, select, checkbox, textarea')
 
-      Array.from(children).forEach((field) => {
-        field.value = ''
-        field.checked = false
-
-        const event = this.wrapper.createEvent('HTMLEvents')
-        event.initEvent('change', true, false)
-        field.dispatchEvent(event)
-      })
-    }
+    Array.from(children).forEach((field) => {
+      if (isVisible) {
+        field.removeAttribute('disabled')
+      } else {
+        field.setAttribute('disabled', 'disabled')
+      }
+    })
   }
 }
 

--- a/spec/javascript/components/conditional_subfield_spec.js
+++ b/spec/javascript/components/conditional_subfield_spec.js
@@ -563,7 +563,7 @@ describe.only('Conditional subfields', () => {
       select.value = 'green'
       ConditionalSubfields.onChange({ target: select })
 
-      expect(document.querySelector('[name="other_colour"]').value).to.equal('')
+      expect(document.querySelector('[name="other_colour"][disabled]').value).to.equal('something')
     })
 
     it('should clear multiple optional fields when they are hidden', () => {
@@ -596,8 +596,8 @@ describe.only('Conditional subfields', () => {
       select.value = 'green'
       ConditionalSubfields.onChange({ target: select })
 
-      expect(document.querySelector('[name="other_colour"]').value).to.equal('')
-      expect(document.querySelector('[name="other_shade"]').value).to.equal('')
+      expect(document.querySelector('[name="other_colour"][disabled]').value).to.equal('something')
+      expect(document.querySelector('[name="other_shade"][disabled]').value).to.equal('dark')
     })
   })
 })


### PR DESCRIPTION
# [Remember value of Other Researcher when returning to edit](https://trello.com/c/xT5221Lh/133-remember-value-of-other-researcher-when-returning-to-edit)

Disable conditional subfields, don't clear the value

We weren't ever restoring the value, but were wiping it on hide so it
made our sometimes-hidden fields look like they'd forgotten the value
from `@research_session`.