### PR TITLE
Make "other researcher" persistent

### DIFF
--- a/app/models/research_session/steps.rb
+++ b/app/models/research_session/steps.rb
@@ -5,8 +5,8 @@ class ResearchSession
     include Singleton
 
     PARAMS = ActiveSupport::OrderedHash[{
-      researcher:    [:researcher_name, :researcher_phone,
-                      :researcher_email, :researcher_other_name, :researcher_other_name],
+      researcher:    [:researcher_name, :researcher_phone, :researcher_email,
+                      :researcher_other, :researcher_other_name, :researcher_other_name],
       topic:         [:topic],
       purpose:       [:purpose],
       methodologies: [:other_methodology, methodologies: []],


### PR DESCRIPTION
# [Remember value of Other Researcher when returning to edit](https://trello.com/c/xT5221Lh/133-remember-value-of-other-researcher-when-returning-to-edit)

We'd forgotten to permit the `researcher_other` boolean field, meaning
that when we returned to the researcher step, even though we'd filled
out a second researcher, that portion of the form remained hidden.

Allow the parameter such that the second researcher is shown.