### PR TITLE
Data sharing label

### DIFF
--- a/app/views/research_sessions/data.html.erb
+++ b/app/views/research_sessions/data.html.erb
@@ -5,7 +5,7 @@
   <%= form_for @research_session, url: wizard_path do %>
 
     <%= radio_group_vertical :shared_with,
-      'Who will data be shared with?',
+      'Who will the data be shared with?',
       SharedWith::NAME_VALUES,
       @research_session.shared_with
     %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,15 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
+  activerecord:
+    attributes:
+      research_session:
+        shared_duration: "How long will this information be held for?"
+        shared_use: "How will the data be used?"
+
+  errors:
+    format: '"%{attribute}" %{message}'
+
   report:
     over18:
       interview: 'You will be interviewed and asked your views regarding the project being researched.'


### PR DESCRIPTION
# [Change 'Shared Use' Error Message to 'Data Sharing'](https://trello.com/c/sgfJn44v/142-1-change-shared-use-error-message-to-data-sharing)

## Ensure Rails knows about attribute labels 

Rails has a place for this kind of thing, in `en.yml`. Under the `en.activerecord.attributes.<model_name>.<attr_name>` keys, add labels for things that aren't currently clear in validations.  Later, with `form_with` and our own builder, we can stop using `labelled_text_field_tag` and duplicating these labels across views, and start using `form.label`.  

Use a specialised formatter for error messages such that the labels are properly quoted (otherwise we get strings that don't read very well)

## Fix some sundry copy

We were missing a 'the' in a sentence
