### PR TITLE
Improve page spacing consistency

### DIFF
--- a/app/assets/stylesheets/barnardos/_checkbox.scss
+++ b/app/assets/stylesheets/barnardos/_checkbox.scss
@@ -17,7 +17,7 @@ $outer-ring: $inner-ring + ($ring-size * 3);
 }
 
 .checkbox-group__legend {
-  font-size: 23px;
+  font-size: $base-font-size;
   font-weight: normal;
   line-height: 24px;
   margin: ($gutter / 2) 0;

--- a/app/assets/stylesheets/barnardos/_fieldset.scss
+++ b/app/assets/stylesheets/barnardos/_fieldset.scss
@@ -6,7 +6,7 @@
 }
 
 .fieldset__legend {
-  font-size: 20px;
+  font-size: 18px;
   font-weight: normal;
   line-height: 32px;
   margin: 12px 0;
@@ -15,7 +15,7 @@
   width: 100%;
 
   @media (min-width: $tablet) {
-    font-size: 36px;
+    font-size: 23px;
     line-height: 48px;
     color: $black;
   }

--- a/app/assets/stylesheets/barnardos/_progress.scss
+++ b/app/assets/stylesheets/barnardos/_progress.scss
@@ -6,7 +6,7 @@
 
   @media (min-width: $tablet) {
     margin: ($gutter * 2) 0;
-    padding-bottom: $gutter / 2;
+    padding-bottom: $gutter * 3;
     padding-left: 30px;
   }
 }

--- a/app/assets/stylesheets/barnardos/_radio.scss
+++ b/app/assets/stylesheets/barnardos/_radio.scss
@@ -17,10 +17,10 @@ $outer-ring: $inner-ring + ($ring-size * 3);
 }
 
 .radio-group__legend {
-  font-size: 23px;
+  font-size: $base-font-size;
   font-weight: normal;
   line-height: 24px;
-  margin: ($gutter / 2) 0;
+  margin: 0 0 ($gutter / 2);
   color: $black;
   float: left;
   width: 100%;

--- a/app/views/research_sessions/data.html.erb
+++ b/app/views/research_sessions/data.html.erb
@@ -1,7 +1,7 @@
 <%= render "research_sessions/progress" %>
 <div class="main-content">
   <%= render 'error_summary' %>
-  <h1 class="visually-hidden">Data usage</h1>
+  <h1 class="subtitle-large">Data</h1>
   <%= form_for @research_session, url: wizard_path do %>
 
     <%= radio_group_vertical :shared_with,

--- a/app/views/research_sessions/expenses.html.erb
+++ b/app/views/research_sessions/expenses.html.erb
@@ -1,7 +1,7 @@
 <%= render "research_sessions/progress" %>
 <div class="main-content">
   <%= render 'error_summary' %>
-  <h2 class="heading-medium">Expenses</h2>
+  <h1 class="subtitle-large">Expenses</h1>
   <%= form_for @research_session, url: wizard_path do %>
 
       <%= labelled_text_field_tag :travel_expenses_limit,

--- a/app/views/research_sessions/incentive.html.erb
+++ b/app/views/research_sessions/incentive.html.erb
@@ -1,7 +1,7 @@
 <%= render "research_sessions/progress" %>
 <div class="main-content">
   <%= render 'error_summary' %>
-  <h2 class="heading-medium">Incentives</h2>
+  <h1 class="subtitle-large">Incentive</h1>
   <%= form_for @research_session, url: wizard_path do %>
       <%= radio_group_vertical :incentive,
                                'Will an incentive be provided?',

--- a/app/views/research_sessions/methodologies.html.erb
+++ b/app/views/research_sessions/methodologies.html.erb
@@ -1,14 +1,13 @@
 <%= render "research_sessions/progress" %>
 <div class="main-content">
   <%= render 'error_summary' %>
-  <h1 class="visually-hidden">Methodologies</h1>
+  <h1 class="subtitle-large">Methodologies</h1>
   <%= form_for @research_session, url: wizard_path do %>
       <%= checkbox_group_vertical(
             'methodologies[]',
             'How will you be gathering information?',
             Methodologies::NAME_VALUES,
-            @research_session.methodologies,
-            legend_options: { class: 'subtitle-large' }
+            @research_session.methodologies
           )
       %>
 

--- a/app/views/research_sessions/purpose.html.erb
+++ b/app/views/research_sessions/purpose.html.erb
@@ -1,16 +1,12 @@
 <%= render "research_sessions/progress" %>
 <div class="main-content">
   <%= render 'error_summary' %>
-  <h1 class="visually-hidden">Research Purpose</h1>
+  <h1 class="subtitle-large">Purpose</h1>
   <%= form_for @research_session, url: wizard_path do %>
       <%= labelled_text_area_tag(
             :purpose,
             'Why are you doing this research or participation session?',
             @research_session.purpose,
-            label_options: {
-              hint: 'Insert aims of the research.',
-              class: 'subtitle-large'
-            },
             text_options: {
               placeholder: 'Barnardo’s needs your help so we can...'
             }

--- a/app/views/research_sessions/recording.html.erb
+++ b/app/views/research_sessions/recording.html.erb
@@ -1,14 +1,13 @@
 <%= render "research_sessions/progress" %>
 <div class="main-content">
   <%= render 'error_summary' %>
-  <h1 class="visually-hidden">Recording Methods</h1>
+  <h1 class="subtitle-large">Recording</h1>
   <%= form_for @research_session, url: wizard_path do %>
       <%= checkbox_group_vertical(
             'recording_methods[]',
             'How will you be recording information?',
             RecordingMethods::NAME_VALUES,
-            @research_session.recording_methods,
-            legend_options: { class: 'subtitle-large' }
+            @research_session.recording_methods
           )
       %>
 

--- a/app/views/research_sessions/researcher.html.erb
+++ b/app/views/research_sessions/researcher.html.erb
@@ -1,23 +1,24 @@
 <%= render "research_sessions/progress" %>
 <div class="main-content">
   <%= render 'error_summary' %>
-  <h1 class="visually-hidden">Researcher</h1>
-  <%= form_for @research_session, url: wizard_path do %>
+  <h1 class="subtitle-large">Researcher</h1>
+  <p>
+    Who is the person who is leading the research or participation session? Please note:
+    participants will be informed that they can get further information from this person,
+    and their contact details will be included on the information sheet.
+  </p>
 
+  <%= form_for @research_session, url: wizard_path do %>
     <fieldset class="fieldset" name="first-researcher">
       <legend class="fieldset__legend">Who will the participants meet as part of the session?</legend>
-      <p>
-        Who is the person who is leading the research or participation session? Please note:
-        participants will be informed that they can get further information from this person,
-        and their contact details will be included on the information sheet.
-      </p>
+
       <%= labelled_text_field_tag :researcher_name, 'Full name', @research_session.researcher_name %>
       <%= labelled_text_field_tag :researcher_phone, 'Telephone number (optional)', @research_session.researcher_phone %>
       <%= labelled_text_field_tag :researcher_email, 'Email', @research_session.researcher_email %>
     </fieldset>
 
     <fieldset class="fieldset" name="second-researcher">
-      <legend class="visually-hidden">Second researcher</legend>
+      <legend class="visually-hidden">Additional researcher</legend>
 
       <%= radio_group_vertical :researcher_other,
         'Will the participants meet any other researchers / participants?',
@@ -28,7 +29,7 @@
       <div class="js-ConditionalSubfield" data-controlled-by="researcher_other" data-control-value="1">
         <%= labelled_text_field_tag :researcher_other_name, 'Full name', @research_session.researcher_other_name %>
       </div>
-    </fieldset>
+    </fielset>
 
     <%= render 'ok_cancel' %>
   <% end %>

--- a/app/views/research_sessions/time_equipment.html.erb
+++ b/app/views/research_sessions/time_equipment.html.erb
@@ -1,7 +1,7 @@
 <%= render "research_sessions/progress" %>
 <div class="main-content">
   <%= render 'error_summary' %>
-  <h1 class="title">Session details</h1>
+  <h1 class="subtitle-large">Time and equipment</h1>
   <%= form_for @research_session, url: wizard_path do %>
 
     <fieldset class="datefield" id="start_datetime">

--- a/app/views/research_sessions/topic.html.erb
+++ b/app/views/research_sessions/topic.html.erb
@@ -1,16 +1,12 @@
 <%= render "research_sessions/progress" %>
 <div class="main-content">
   <%= render 'error_summary' %>
-  <h1 class="visually-hidden">Research Topic</h1>
+  <h1 class="subtitle-large">Topic</h1>
   <%= form_for @research_session, url: wizard_path do %>
       <%= labelled_text_area_tag(
             :topic,
             'What is the research or participation session about?',
             @research_session.topic,
-            label_options: {
-              hint: 'What is the research about?',
-              class: 'subtitle-large'
-            },
             text_options: {
               placeholder: 'The topic of the project is...'
             }


### PR DESCRIPTION
![screenshot from 2017-09-12 11-54-32](https://user-images.githubusercontent.com/56056/30323352-ce4a19c0-97b4-11e7-8283-ed894164058b.png)

* Adjusted the progress bar to result in a consistent height.
*  Swited page headings to consistent structure for consistent heading sizes and spacing
* Adjusted radio headings to fix spacing oddity.