### PR TITLE
Remove last FormTagHelper reference

### DIFF
--- a/app/controllers/gallery_controller.rb
+++ b/app/controllers/gallery_controller.rb
@@ -1,7 +1,4 @@
 class GalleryController < ApplicationController
-  helper Barnardos::ActionView::FormTagHelper
-
   def index
   end
-
 end


### PR DESCRIPTION
This was missed; no longer exists