### PR TITLE
Make research sessions addressable

### DIFF
--- a/app/controllers/research_sessions_controller.rb
+++ b/app/controllers/research_sessions_controller.rb
@@ -10,11 +10,12 @@ class ResearchSessionsController < ApplicationController
   end
 
   def index
+    @research_session = ResearchSession.new
   end
 
-  def start
-    session[:current_research_session_id] = nil
-    redirect_to(first_question_path)
+  def create
+    session_id = ResearchSession.create.id
+    redirect_to(first_question_path(session_id))
   end
 
   def show
@@ -46,15 +47,11 @@ class ResearchSessionsController < ApplicationController
 
 private
   def current_research_session
-    id = session[:current_research_session_id]
-    research_session = ResearchSession.find(id) if id.present?
-    research_session ||= ResearchSession.create
-    session[:current_research_session_id] = research_session.id
-    research_session
+    ResearchSession.find(params[:research_session_id])
   end
 
-  def first_question_path
-    question_path(id: steps.first)
+  def first_question_path(id)
+    research_session_question_path(research_session_id: id, id: steps.first)
   end
 
   def question_params

--- a/app/helpers/research_sessions_helper.rb
+++ b/app/helpers/research_sessions_helper.rb
@@ -4,6 +4,7 @@ module ResearchSessionsHelper
 
     step_for_attr = ResearchSession::Steps.instance.attr_to_step(attr)
 
-    link_to value, question_path(step_for_attr), class: 'editable'
+    link_to value,
+            research_session_question_path(@research_session, step_for_attr), class: 'editable'
   end
 end

--- a/app/presenters/research_session_presenter.rb
+++ b/app/presenters/research_session_presenter.rb
@@ -1,5 +1,5 @@
 class ResearchSessionPresenter < Struct.new(:research_session)
-  delegate :age, :topic, :purpose, :researcher_name, :researcher_other_name,
+  delegate :id, :age, :topic, :purpose, :researcher_name, :researcher_other_name,
            :researcher_email, :researcher_phone, :unable_to_consent?,
            :able_to_consent?, :other_methodology, :other_recording_method,
            :reached_step?, to: :research_session

--- a/app/views/research_sessions/_progress.html.erb
+++ b/app/views/research_sessions/_progress.html.erb
@@ -5,7 +5,7 @@
 
     <li class="progress__stage is-complete">
       <span class="progress__stage-title">
-        <%= link_to 'Start', start_path %>
+        <%= link_to 'Start', root_path %>
       </span>
     </li>
 
@@ -23,7 +23,7 @@
           <%= 'is-active' if this_step == step %>">
         <span class="progress__stage-title">
           <% if this_step != step and @research_session and @research_session.reached_step?(this_step) %>
-            <%= link_to this_step.to_s.humanize, question_path(this_step) %>
+            <%= link_to this_step.to_s.humanize, research_session_question_path(@research_session.id, this_step) %>
           <% else %>
             <%= this_step.to_s.humanize %>
           <% end %>
@@ -38,7 +38,7 @@
     <li class="progress__stage <%= 'is-active' if preview %>">
       <span class="progress__stage-title">
         <% if !preview && @research_session && @research_session.reached_step?(wizard_steps.last) %>
-          <%= link_to 'Preview', research_session_preview_path %>
+          <%= link_to 'Preview', research_session_preview_path(@research_session.id) %>
         <% else %>
           Preview
         <% end %>

--- a/app/views/research_sessions/index.html.erb
+++ b/app/views/research_sessions/index.html.erb
@@ -5,5 +5,7 @@
   for your project(s).
 </p>
 <p class="button-bar">
-  <%= link_to 'Create new form', start_path, class: 'button'  %>
+  <%= form_with model: @research_session do %>
+    <button class="button" type="submit">Create new form</button>
+  <% end %>
 </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,10 +2,10 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: 'research_sessions#index'
 
-  get '/start', to: 'research_sessions#start'
+  resources :research_sessions, only: [:show, :create], path: 'research-sessions' do
+    resources :questions, only: [:show, :update], controller: 'research_sessions'
+    get :preview
+  end
 
-  resources :questions, only: [:show, :update], controller: 'research_sessions'
-
-  get 'research-session/preview', to: 'research_sessions#preview'
   get '/gallery/', to: 'gallery#index'
 end

--- a/features/printed_consent_forms.feature
+++ b/features/printed_consent_forms.feature
@@ -23,3 +23,8 @@ Feature:
     Then I should see the session review page
     And I should see my 'Other' methodology
     And I should see my 'Other' recording method
+
+  Scenario: Beginning a new session
+    When I begin a new session at the start
+    Then the session should be immediately addressable
+

--- a/features/step_definitions/aids_for_devops_steps.rb
+++ b/features/step_definitions/aids_for_devops_steps.rb
@@ -27,5 +27,5 @@ When(/^I visit the home page$/) do
 end
 
 When(/^I start to create a form$/) do
-  click_link 'Create new form'
+  click_button 'Create new form'
 end

--- a/features/step_definitions/question_steps.rb
+++ b/features/step_definitions/question_steps.rb
@@ -1,6 +1,6 @@
 When(/^I provide full session details for a child-age cohort$/) do
   visit '/'
-  click_link 'Create new form'
+  click_button 'Create new form'
 
   within '[name="first-researcher"]' do
     fill_in 'Full name', with: 'Rachel Researcher'
@@ -81,7 +81,7 @@ end
 
 Given(/^I have arrived at the methodologies step$/) do
   visit '/'
-  click_link 'Create new form'
+  click_button 'Create new form'
 
   within '[name="first-researcher"]' do
     fill_in 'Full name', with: 'Rachel Researcher'
@@ -174,4 +174,9 @@ And(/^I provide an 'Other' recording method$/) do
   step "I should see an 'Other' checkbox for recording methods with a space to fill this in"
   step "I fill in the 'Other' recording method"
   step 'I click the continue button'
+end
+
+When(/^I begin a new session at the start$/) do
+  visit '/'
+  click_button 'Create new form'
 end

--- a/features/step_definitions/session_review_steps.rb
+++ b/features/step_definitions/session_review_steps.rb
@@ -24,7 +24,7 @@ end
 
 And(/^I should see links back to edit things that I provided$/) do
   ResearchSession::Steps.instance.step_keys.each do |step|
-    expect(page).to have_tag('a', href: question_path(step))
+    expect(page).to have_tag('a', href: Regexp.new("^/research-sessions/[0-9]*/questions/#{step}/"))
   end
 end
 
@@ -42,4 +42,8 @@ end
 
 And(/^I should see my 'Other' recording method$/) do
   expect(page).to have_content(@other_recording_method)
+end
+
+Then(/^the session should be immediately addressable$/) do
+  expect(page.current_path).to match(%r{^/research-sessions/[0-9]*/questions/researcher})
 end


### PR DESCRIPTION
# [Make URLs returnable](https://trello.com/c/Su0Kmc51/150-make-urls-returnable)

When I create a consent form, I want to be able to return to the form, so I can carry on where I left off.

When I have finished creating a form, I want to be able to return to the form, so I can print it out and use it for my research sessions.

## Acceptance criteria
Make the URL of the research session addressable. The current state: `/questions/researcher` should change to e.g.

`/sessions/1234/questions/researcher`

or

`/sessions/1234-autogenerated-text-from-topic/questions/researcher`

Also address the session creation semantics problem, i.e. it was
possible to create a session by visiting `/start`. Make that a POST to
`/research-sessions` instead, which is more Rails-y and lets us just add
`:create` to the resources definition in `routes.rb`