### PR TITLE
Convert to factory_girl

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :test do
   gem 'cucumber-rails', require: false
   gem 'database_cleaner'
   gem 'launchy'
+  gem 'factory_girl_rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,11 @@ GEM
     diff-lcs (1.3)
     erubi (1.6.1)
     execjs (2.7.0)
+    factory_girl (4.8.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.8.0)
+      factory_girl (~> 4.8.0)
+      railties (>= 3.0.0)
     ffi (1.9.18)
     gherkin (4.1.3)
     globalid (0.4.0)
@@ -236,6 +241,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   cucumber-rails
   database_cleaner
+  factory_girl_rails
   jbuilder (~> 2.5)
   launchy
   listen (>= 3.0.5, < 3.2)

--- a/spec/factories/research_session.rb
+++ b/spec/factories/research_session.rb
@@ -1,0 +1,59 @@
+FactoryGirl.define do
+  factory :research_session do
+    factory :researcher do
+      status :researcher
+      researcher_name 'Rachel Researcher'
+      researcher_email 'r.researcher@barnardos.org.uk'
+    end
+
+    factory :topic, parent: :researcher do
+      status :topic
+      topic 'A topic'
+    end
+
+    factory :purpose, parent: :topic do
+      status :purpose
+      purpose 'A purpose'
+    end
+
+    factory :methodologies, parent: :purpose do
+      status :methodologies
+      methodologies %w[interview survey]
+    end
+
+    factory :recording, parent: :methodologies do
+      status :recording
+      recording_methods %w[audio video]
+    end
+
+    factory :data, parent: :recording do
+      status :data
+      shared_with :team
+      shared_duration '1 year'
+      shared_use 'To train others'
+    end
+
+    factory :time_equipment, parent: :data do
+      status :time_equipment
+      start_datetime DateTime.parse('1st Sep 2017')
+      duration '1 week'
+      participant_equipment 'A coat'
+    end
+
+    factory :expenses, parent: :time_equipment do
+      status :expenses
+      travel_expenses_limit '10.00'
+      food_expenses_limit '20.00'
+      other_expenses_limit '1.00'
+      receipts_required true
+      food_provided 'Light canapés'
+    end
+
+    factory :incentive, parent: :expenses do
+      status :incentive
+      incentive true
+      payment_type :cash
+      incentive_value '40.00'
+    end
+  end
+end

--- a/spec/models/research_session_spec.rb
+++ b/spec/models/research_session_spec.rb
@@ -8,12 +8,6 @@ RSpec.describe ResearchSession, type: :model do
       expect(session.status).to eql('new')
     end
 
-    it 'allows us to create a session with no details' do
-      new_session = ResearchSession.create
-      expect(new_session).to be_valid
-      expect(new_session).to be_persisted
-    end
-
     describe '#un/able_to_consent?' do
       before { session.age = age }
       context 'is too young' do
@@ -38,15 +32,25 @@ RSpec.describe ResearchSession, type: :model do
     end
 
     describe 'step-by-step validation' do
+      let(:step)      { :new }
+      let(:set_attrs) { {} }
+
       before do
         session.status = step
-        session.save
+        if step != :new
+          attrs = attributes_for(step)
+          session.assign_attributes(attrs.merge(set_attrs))
+        end
+        session.validate
       end
 
       describe 'validating the researcher step' do
-        let(:step) { 'researcher' }
-
         context 'no details are given' do
+          before do
+            session.status = :researcher
+            session.validate
+          end
+
           it { is_expected.not_to be_valid }
           it 'has an error for researcher name' do
             expect(session.errors[:researcher_name].length).to eql(1)
@@ -56,13 +60,9 @@ RSpec.describe ResearchSession, type: :model do
           end
         end
 
-        context "all the details are given but the email isn't one" do
-          before do
-            session.researcher_name  = 'Miss Havisham'
-            session.researcher_phone = '12345678'
-            session.researcher_email = 'xxxxxxxxx'
-            session.save
-          end
+        context "all the details are given but the email isn't valid" do
+          let(:step) { :researcher }
+          let(:set_attrs) { { researcher_email: 'xxxxxxxx' } }
 
           it { is_expected.not_to be_valid }
           it 'has an error for email' do
@@ -72,91 +72,50 @@ RSpec.describe ResearchSession, type: :model do
         end
 
         context 'all the details are given' do
-          before do
-            session.researcher_name  = 'Miss Havisham'
-            session.researcher_phone = '12345678'
-            session.researcher_email = 'a@b.com'
-            session.save
-          end
-
           it { is_expected.to be_valid }
         end
       end
 
       describe 'validating the topic step' do
-        let(:step) { 'topic' }
-
-        before do
-          session.researcher_name  = 'Miss Havisham'
-          session.researcher_phone = '12345678'
-          session.researcher_email = 'a@b.com'
-        end
+        let(:step) { :topic }
 
         context 'no topic is given' do
+          let(:set_attrs) { { topic: nil } }
           it { is_expected.not_to be_valid }
         end
 
         context 'research topic is given' do
-          before do
-            session.topic = 'A nice long topic description'
-            session.save
-          end
           it { is_expected.to be_valid }
         end
       end
 
       describe 'validating the purpose step' do
-        let(:step) { 'purpose' }
-
-        before do
-          session.researcher_name  = 'Miss Havisham'
-          session.researcher_phone = '12345678'
-          session.researcher_email = 'a@b.com'
-          session.topic = 'A nice long topic description'
-        end
+        let(:step) { :purpose }
 
         context 'no purpose is given' do
+          let(:set_attrs) { { purpose: nil } }
           it { is_expected.not_to be_valid }
         end
 
         context 'research purpose is given' do
-          before do
-            session.purpose = 'A nice long purpose description'
-            session.save
-          end
           it { is_expected.to be_valid }
         end
       end
 
       describe 'validating the methodologies step' do
-        let(:step) { 'methodologies' }
-
-        before do
-          session.researcher_name  = 'Miss Havisham'
-          session.researcher_phone = '12345678'
-          session.researcher_email = 'a@b.com'
-          session.topic = 'A nice long topic description'
-          session.purpose = 'A nice long purpose description'
-        end
+        let(:step) { :methodologies }
 
         context 'no methodologies are selected' do
+          let(:set_attrs) { { methodologies: nil } }
           it { is_expected.not_to be_valid }
         end
 
         context 'at least one valid methodology is selected' do
-          before do
-            session.methodologies = [:interview]
-            session.save
-          end
           it { is_expected.to be_valid }
         end
 
         context 'the "other" methodology is selected' do
-          before do
-            session.methodologies = [:other]
-            session.other_methodology = other_methodology
-            session.save
-          end
+          let(:set_attrs) { { methodologies: [:other], other_methodology: other_methodology } }
 
           context 'other methodology is blank' do
             let(:other_methodology) { nil }
@@ -166,6 +125,7 @@ RSpec.describe ResearchSession, type: :model do
               expect(session.errors[:other_methodology].first).to eql("can't be blank")
             end
           end
+
           context 'other methodology is supplied' do
             let(:other_methodology) { 'Another methodology' }
             it { is_expected.to be_valid }
@@ -174,34 +134,23 @@ RSpec.describe ResearchSession, type: :model do
       end
 
       describe 'validating the recording step' do
-        let(:step) { 'recording' }
-
-        before do
-          session.researcher_name  = 'Miss Havisham'
-          session.researcher_phone = '12345678'
-          session.researcher_email = 'a@b.com'
-          session.topic = 'A nice long topic description'
-          session.purpose = 'A nice long purpose description'
-          session.methodologies = [Methodologies.allowed_values.first]
-        end
+        let(:step) { :recording }
 
         context 'no recording methods are selected' do
+          let(:set_attrs) { { recording_methods: nil } }
           it { is_expected.not_to be_valid }
         end
 
         context 'at least one valid method is selected' do
-          before do
-            session.recording_methods = [:audio]
-            session.save
-          end
           it { is_expected.to be_valid }
         end
 
         context 'the "other" recording methods is selected' do
-          before do
-            session.recording_methods = [:other]
-            session.other_recording_method = other_recording_method
-            session.save
+          let(:set_attrs) do
+            {
+              recording_methods: [:other],
+              other_recording_method: other_recording_method
+            }
           end
 
           context 'other methodology is blank' do
@@ -220,19 +169,10 @@ RSpec.describe ResearchSession, type: :model do
       end
 
       describe 'validating the data step' do
-        let(:step) { 'data' }
+        let(:step) { :data }
 
-        before do
-          session.researcher_name  = 'Miss Havisham'
-          session.researcher_phone = '12345678'
-          session.researcher_email = 'a@b.com'
-          session.topic = 'A nice long topic description'
-          session.purpose = 'A nice long purpose description'
-          session.methodologies = [Methodologies.allowed_values.first]
-          session.recording_methods = [RecordingMethods.allowed_values.first]
-        end
-
-        context 'no details are give' do
+        context 'no details are given' do
+          let(:set_attrs) { { shared_with: nil, shared_duration: nil, shared_use: nil } }
           it { is_expected.not_to be_valid }
           it 'has an error for shared with' do
             expect(session.errors[:shared_with].length).to eql(1)
@@ -246,12 +186,7 @@ RSpec.describe ResearchSession, type: :model do
         end
 
         context 'all the details are given but the shared_with team is invalid' do
-          before do
-            session.shared_with = 'nobody'
-            session.shared_duration = '1 week'
-            session.shared_use = 'xxxxxxxxx'
-            session.save
-          end
+          let(:set_attrs) { { shared_with: 'nobody_useful' } }
 
           it { is_expected.not_to be_valid }
           it 'has an error for shared with' do
@@ -261,48 +196,23 @@ RSpec.describe ResearchSession, type: :model do
         end
 
         context 'all the details are given' do
-          before do
-            session.shared_with = SharedWith.allowed_values.first
-            session.shared_duration = '1 week'
-            session.shared_use = 'xxxxxxxxx'
-            session.save
-          end
-
           it { is_expected.to be_valid }
         end
       end
 
       describe 'validating the incentive step' do
-        let(:step) { 'incentive' }
-
-        before do
-          session.methodologies = [Methodologies.allowed_values.first]
-          session.recording_methods = [RecordingMethods.allowed_values.first]
-          session.topic = 'A nice long topic description'
-          session.purpose = 'A nice long purpose description'
-          session.researcher_name  = 'Miss Havisham'
-          session.researcher_phone = '12345678'
-          session.researcher_email = 'a@b.com'
-          session.shared_with = SharedWith.allowed_values.first
-          session.shared_duration = '1 week'
-          session.shared_use = 'xxxxxxxxx'
-          session.save
-        end
+        let(:step) { :incentive }
 
         context 'no incentives are given, and no-one cares' do
-          it 'sets an appropriate default anyway' do
-            expect(session.incentive).to be false
-          end
+          let(:set_attrs) { { incentive: nil } }
+
           it { is_expected.to be_valid }
         end
 
         context 'incentives are on' do
-          before do
-            session.incentive = true
-            session.save
-          end
-
           context 'but no option has been set' do
+            let(:set_attrs) { { payment_type: nil } }
+
             it { is_expected.not_to be_valid }
             it 'has an error on payment_type' do
               expect(session.errors[:payment_type].length).to eql(1)
@@ -311,20 +221,18 @@ RSpec.describe ResearchSession, type: :model do
           end
 
           context 'an option has been set' do
-            before do
-              session.payment_type = :cash
-              session.save
-            end
             context 'but no incentive_value has been provided' do
+              let(:set_attrs) { { incentive_value: nil } }
+
               it { is_expected.not_to be_valid }
               it 'has an error on incentive_value' do
                 expect(session.errors[:incentive_value].length).to eql(1)
                 expect(session.errors[:incentive_value].first).to match(/can't be blank/)
               end
             end
+
             context 'and an incentive_value has been provided' do
-              before { session.incentive_value = 10.00 }
-              it     { is_expected.to be_valid }
+              it { is_expected.to be_valid }
             end
           end
         end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,7 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
+require 'support/factory_girl'
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'spec_helper'

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
+end


### PR DESCRIPTION
There was a lot of [duplication](https://github.com/barnardos/consent-form-builder-rails/blob/master/spec/models/research_session_spec.rb#L279-L289) in `research_session_spec.rb` with respect to setting up models. Suddenly we need to do the same kind of thing again in order to set up tests to [redirect to partially-completed forms](https://trello.com/c/Su0Kmc51/150-make-urls-returnable#comment-59bfa06495ff1052eadba0d3).

Rather than pollute `research_controller_spec.rb` with similar duplication, make a factory for each `ResearchSession::Steps` step.