### PR TITLE
Tidy up the inline error styles

### DIFF
--- a/app/assets/stylesheets/barnardos/_checkbox.scss
+++ b/app/assets/stylesheets/barnardos/_checkbox.scss
@@ -20,6 +20,28 @@ $outer-ring: $inner-ring + ($ring-size * 3);
   margin-top: ($gutter / 2);
   color: $black;
   width: 100%;
+
+  .has-error & {
+    position: relative;
+    padding-right: ($error-icon-size + $gutter + $gutter / 2);
+
+    &::after {
+      content: "!";
+      position: absolute;
+      right: $gutter;
+      top: -2px;
+      width: $error-icon-size;
+      height: $error-icon-size;
+      padding: 5px;
+      border: 1px solid $error-colour;
+      border-radius: 100%;
+      box-sizing: border-box;
+      color: $error-colour;
+      line-height: .65;
+      font-weight: bold;
+      text-align: center;
+    }
+  }
 }
 
 .checkbox-group__choice {

--- a/app/assets/stylesheets/barnardos/_checkbox.scss
+++ b/app/assets/stylesheets/barnardos/_checkbox.scss
@@ -17,12 +17,8 @@ $outer-ring: $inner-ring + ($ring-size * 3);
 }
 
 .checkbox-group__legend {
-  font-size: $base-font-size;
-  font-weight: normal;
-  line-height: 24px;
-  margin: ($gutter / 2) 0;
+  margin-top: ($gutter / 2);
   color: $black;
-  float: left;
   width: 100%;
 }
 

--- a/app/assets/stylesheets/barnardos/_radio.scss
+++ b/app/assets/stylesheets/barnardos/_radio.scss
@@ -20,6 +20,28 @@ $outer-ring: $inner-ring + ($ring-size * 3);
   margin-top: ($gutter / 2);
   color: $black;
   width: 100%;
+
+  .has-error & {
+    position: relative;
+    padding-right: ($error-icon-size + $gutter + $gutter / 2);
+
+    &::after {
+      content: "!";
+      position: absolute;
+      right: $gutter;
+      top: -2px;
+      width: $error-icon-size;
+      height: $error-icon-size;
+      padding: 5px;
+      border: 1px solid $error-colour;
+      border-radius: 100%;
+      box-sizing: border-box;
+      color: $error-colour;
+      line-height: .65;
+      font-weight: bold;
+      text-align: center;
+    }
+  }
 }
 
 .radio-group__choice {

--- a/app/assets/stylesheets/barnardos/_radio.scss
+++ b/app/assets/stylesheets/barnardos/_radio.scss
@@ -17,12 +17,8 @@ $outer-ring: $inner-ring + ($ring-size * 3);
 }
 
 .radio-group__legend {
-  font-size: $base-font-size;
-  font-weight: normal;
-  line-height: 24px;
-  margin: 0 0 ($gutter / 2);
+  margin-top: ($gutter / 2);
   color: $black;
-  float: left;
   width: 100%;
 }
 

--- a/app/assets/stylesheets/barnardos/_textarea.scss
+++ b/app/assets/stylesheets/barnardos/_textarea.scss
@@ -1,8 +1,6 @@
 @import "barnardos/colours";
 @import "barnardos/vars";
 
-$error-icon-size: 22px;
-
 .textarea {
   margin: $gutter 0 $gutter (-$gutter / 2);
   max-width: $max-form-control-width;
@@ -27,7 +25,7 @@ $error-icon-size: 22px;
   margin-top: $gutter / 2;
   position: relative;
 
-  .has-error > & {
+  .has-error & {
     position: relative;
     padding-right: ($error-icon-size + $gutter + $gutter / 2);
 

--- a/app/assets/stylesheets/barnardos/_textarea.scss
+++ b/app/assets/stylesheets/barnardos/_textarea.scss
@@ -1,10 +1,12 @@
 @import "barnardos/colours";
 @import "barnardos/vars";
 
+$error-icon-size: 22px;
+
 .textarea {
   margin: $gutter 0 $gutter (-$gutter / 2);
   max-width: $max-form-control-width;
-  padding: $gutter / 2;
+  padding: ($gutter / 2) ($gutter / 2) $gutter;
   position: relative;
 }
 
@@ -23,21 +25,28 @@
   color: $black;
   font-weight: normal;
   margin-top: $gutter / 2;
+  position: relative;
 
-  .has-error &::after {
-    content: "!";
-    border: 2px solid $error-colour;
-    border-radius: 100%;
-    box-sizing: border-box;
-    color: $error-colour;
-    height: 1.5em;
-    line-height: .75;
-    padding: 5px;
-    position: absolute;
-    right: $gutter;
-    text-align: center;
-    top: $gutter;
-    width: 1.5em;
+  .has-error > & {
+    position: relative;
+    padding-right: ($error-icon-size + $gutter + $gutter / 2);
+
+    &::after {
+      content: "!";
+      position: absolute;
+      right: $gutter;
+      top: -2px;
+      width: $error-icon-size;
+      height: $error-icon-size;
+      padding: 5px;
+      border: 1px solid $error-colour;
+      border-radius: 100%;
+      box-sizing: border-box;
+      color: $error-colour;
+      line-height: .65;
+      font-weight: bold;
+      text-align: center;
+    }
   }
 }
 

--- a/app/assets/stylesheets/barnardos/_textarea.scss
+++ b/app/assets/stylesheets/barnardos/_textarea.scss
@@ -64,10 +64,6 @@ $error-icon-size: 22px;
   width: 100%;
 }
 
-.textarea.has-error .textarea__input {
-  border: 1px solid $error-colour;
-}
-
 .textarea__hint {
   color: $secondary-text;
   display: block;

--- a/app/assets/stylesheets/barnardos/_textfield.scss
+++ b/app/assets/stylesheets/barnardos/_textfield.scss
@@ -25,7 +25,6 @@
 }
 
 .textfield.has-error .textfield__label {
-  color: $error-colour;
 }
 
 .textfield__input {
@@ -39,10 +38,6 @@
   border: solid 1px $border;
   border-radius: $border-radius;
   outline: none;
-}
-
-.textfield.has-error .textfield__input {
-  border: 1px solid $error-colour;
 }
 
 .textfield__hint {

--- a/app/assets/stylesheets/barnardos/_textfield.scss
+++ b/app/assets/stylesheets/barnardos/_textfield.scss
@@ -22,9 +22,29 @@
   font-weight: normal;
   color: $black;
   margin-top: $gutter / 2;
-}
+  position: relative;
 
-.textfield.has-error .textfield__label {
+  .has-error & {
+    position: relative;
+    padding-right: ($error-icon-size + $gutter + 10px);
+
+    &::after {
+      content: "!";
+      position: absolute;
+      right: $gutter;
+      top: -2px;
+      width: $error-icon-size;
+      height: $error-icon-size;
+      padding: 5px;
+      border: 1px solid $error-colour;
+      border-radius: 100%;
+      box-sizing: border-box;
+      color: $error-colour;
+      line-height: .65;
+      font-weight: bold;
+      text-align: center;
+    }
+  }
 }
 
 .textfield__input {

--- a/app/assets/stylesheets/barnardos/_vars.scss
+++ b/app/assets/stylesheets/barnardos/_vars.scss
@@ -11,3 +11,4 @@ $corner-radius: 2px;
 $base-font-size: 18px;
 $base-mobile-font-size: 16px;
 $border-radius: 2px;
+$error-icon-size: 22px;

--- a/app/helpers/barnardos/action_view/form_helper.rb
+++ b/app/helpers/barnardos/action_view/form_helper.rb
@@ -91,10 +91,12 @@ module Barnardos
 
           # Render a legend for the fieldset, with an optional hint and optional class
           concat(
-            content_tag(:legend, class: "radio-group__legend #{legend_options[:class]}") do
-              concat(legend)
-              if legend_options[:hint]
-                concat(content_tag(:span, legend_options[:hint], class: 'radio-group__hint'))
+            content_tag(:span) do
+              content_tag(:legend, class: "radio-group__legend #{legend_options[:class]}") do
+                concat(legend)
+                if legend_options[:hint]
+                  concat(content_tag(:span, legend_options[:hint], class: 'radio-group__hint'))
+                end
               end
             end
           )
@@ -121,10 +123,12 @@ module Barnardos
           next unless collection.any?
 
           concat(
-            content_tag(:legend, class: "checkbox-group__legend #{legend_options[:class]}") do
-              concat(legend)
-              if legend_options[:hint]
-                concat(content_tag(:span, legend_options[:hint], class: 'checkbox-group__hint'))
+            content_tag(:span) do
+              content_tag(:legend, class: "checkbox-group__legend #{legend_options[:class]}") do
+                concat(legend)
+                if legend_options[:hint]
+                  concat(content_tag(:span, legend_options[:hint], class: 'checkbox-group__hint'))
+                end
               end
             end
           )


### PR DESCRIPTION
# [Tidy up the inline error styles](https://trello.com/c/qmwS3Q2b/164-tidy-up-the-inline-error-styles)

Tidying up the error state styles for textfields and textareas that are present in the screenshot featured in https://github.com/barnardos/consent-form-builder-rails/pull/93. These updates bring the styles more inline with the styleguide.

## Screenshot:

![image](https://user-images.githubusercontent.com/893208/30593538-d349894a-9d42-11e7-995a-e6a620118adb.png)
