### PR TITLE
Avoid a double label in labelled_text_area

### DIFF
--- a/app/helpers/barnardos/action_view/form_helper.rb
+++ b/app/helpers/barnardos/action_view/form_helper.rb
@@ -66,7 +66,15 @@ module Barnardos
         wrapper_tag(object_name, method, class: 'textarea js-highlight-control') do
           concat(
             label(object_name, method, label_options) do
-              concat(label.present? ? label : label(object_name, method, label_options))
+              if label.present?
+                concat(label)
+              else
+                concat(
+                  ::ActionView::Helpers::Tags::Translator.new(
+                    nil, object_name.to_s, method.to_s, scope: 'helpers.label'
+                  ).translate
+                )
+              end
               if label_options[:hint]
                 concat(content_tag(:span, label_options[:hint], class: 'textarea__hint'))
               end

--- a/spec/helpers/barnardos/action_view/form_helper_spec.rb
+++ b/spec/helpers/barnardos/action_view/form_helper_spec.rb
@@ -209,6 +209,10 @@ RSpec.describe Barnardos::ActionView::FormHelper, type: :helper do
       it 'renders an error class on the wrapper div' do
         expect(rendered).to have_tag('div.has-error')
       end
+
+      it 'does not render a label within a label' do
+        expect(rendered).not_to have_tag('label label')
+      end
     end
   end
 


### PR DESCRIPTION
# [BUG: When a textarea has an error, form helper outputs a label within a label](https://trello.com/c/XDkR3yhr/165-bug-when-a-textarea-has-an-error-form-helper-outputs-a-label-within-a-label)

We were relying on the Rails `FormHelper#label` method to look up a
label from translations for us. Unfortunately this was inside another
label. Really we need the translation on its own, which is... well, it's
pretty ugly (nil first param as we don't have an object, need to make
the rest of the params strings, need to point to the idiomatic home for
labels as a scope).