### PR TITLE
Remove the cancel button

### DIFF
--- a/app/views/research_sessions/_button_bar.erb
+++ b/app/views/research_sessions/_button_bar.erb
@@ -1,4 +1,3 @@
 <p class="button-bar">
   <%= button_tag('Continue', type: :submit, class: 'button') %>
-  <%= link_to 'Cancel', root_path, class: 'button button--secondary' %>
 </p>

--- a/app/views/research_sessions/data.html.erb
+++ b/app/views/research_sessions/data.html.erb
@@ -16,6 +16,6 @@
           :shared_use, text_options: { placeholder: 'The data will be used to...' }
     %>
 
-    <%= render 'ok_cancel' %>
+    <%= render 'button_bar' %>
   <% end %>
 </div>

--- a/app/views/research_sessions/expenses.html.erb
+++ b/app/views/research_sessions/expenses.html.erb
@@ -23,6 +23,6 @@
 
       <%= form.labelled_text_area :food_provided %>
 
-      <%= render 'ok_cancel' %>
+      <%= render 'button_bar' %>
   <% end %>
 </div>

--- a/app/views/research_sessions/incentive.html.erb
+++ b/app/views/research_sessions/incentive.html.erb
@@ -15,6 +15,6 @@
 
       <%= form.labelled_text_field :incentive_value %>
 
-      <%= render 'ok_cancel' %>
+      <%= render 'button_bar' %>
   <% end %>
 </div>

--- a/app/views/research_sessions/methodologies.html.erb
+++ b/app/views/research_sessions/methodologies.html.erb
@@ -16,6 +16,6 @@
         <%= form.labelled_text_field :other_methodology %>
       </div>
 
-      <%= render 'ok_cancel' %>
+      <%= render 'button_bar' %>
   <% end %>
 </div>

--- a/app/views/research_sessions/purpose.html.erb
+++ b/app/views/research_sessions/purpose.html.erb
@@ -11,6 +11,6 @@
           )
       %>
 
-      <%= render 'ok_cancel' %>
+      <%= render 'button_bar' %>
   <% end %>
 </div>

--- a/app/views/research_sessions/recording.html.erb
+++ b/app/views/research_sessions/recording.html.erb
@@ -16,6 +16,6 @@
         <%= form.labelled_text_field :other_recording_method %>
       </div>
 
-      <%= render 'ok_cancel' %>
+      <%= render 'button_bar' %>
   <% end %>
 </div>

--- a/app/views/research_sessions/researcher.html.erb
+++ b/app/views/research_sessions/researcher.html.erb
@@ -30,6 +30,6 @@
       </div>
     </fieldset>
 
-    <%= render 'ok_cancel' %>
+    <%= render 'button_bar' %>
   <% end %>
 </div>

--- a/app/views/research_sessions/time_equipment.html.erb
+++ b/app/views/research_sessions/time_equipment.html.erb
@@ -13,6 +13,6 @@
 
     <%= form.labelled_text_area :participant_equipment %>
 
-    <%= render 'ok_cancel' %>
+    <%= render 'button_bar' %>
   <% end %>
 </div>

--- a/app/views/research_sessions/topic.html.erb
+++ b/app/views/research_sessions/topic.html.erb
@@ -10,6 +10,6 @@
           }
       %>
 
-      <%= render 'ok_cancel' %>
+      <%= render 'button_bar' %>
   <% end %>
 </div>


### PR DESCRIPTION
# [Remove Cancel button](https://trello.com/c/XWoysuWu/107-1-remove-cancel-button)

Scarily close to the OK button, even though you can cancel your cancel
by clicking the 'back' button in your browser, it is still dangerous
ju-ju. Remove it, and rename the partial it appears in so as not to
mislead