### PR TITLE
Allow tabbing in checkboxes

### DIFF
--- a/app/assets/stylesheets/barnardos/_checkbox.scss
+++ b/app/assets/stylesheets/barnardos/_checkbox.scss
@@ -56,7 +56,8 @@ $outer-ring: $inner-ring + ($ring-size * 3);
 }
 
 .checkbox-group__input {
-  display: none;
+  opacity: 0;
+  position: absolute;
 }
 
 .checkbox-group__input + .checkbox-group__label {
@@ -77,19 +78,20 @@ $outer-ring: $inner-ring + ($ring-size * 3);
   width: $base-font-size;
 }
 
-.checkbox-group__input:hover + .checkbox-group__label::before {
+.checkbox-group__input:hover + .checkbox-group__label::before,
+.checkbox-group__input:focus + .checkbox-group__label::before {
   background: $grey-medium;
-  box-shadow: 0 0 0 $inner-ring $grey-medium, 0 0 0 $border-ring $black, 0 0 0 $outer-ring $grey-medium;
-}
-
-.checkbox-group__input:checked:hover + .checkbox-group__label::before {
-  background: $primary;
   box-shadow: 0 0 0 $inner-ring $grey-medium, 0 0 0 $border-ring $black, 0 0 0 $outer-ring $grey-medium;
 }
 
 .checkbox-group__input:checked + .checkbox-group__label::before {
   background-color: $primary;
   box-shadow: 0 0 0 $inner-ring $white, 0 0 0 $border-ring $black;
+}
+
+.checkbox-group__input:checked:focus + .checkbox-group__label::before {
+  background-color: $primary;
+  box-shadow: 0 0 0 $inner-ring $grey-medium, 0 0 0 $border-ring $black, 0 0 0 $outer-ring $grey-medium;
 }
 
 .checkbox-group__input:disabled + .checkbox-group__label::before {


### PR DESCRIPTION
# [Tabbing through checkboxes isn't working](https://trello.com/c/AtwZN5N8/136-tabbing-through-checkboxes-isnt-working)

<img width="394" alt="screen shot 2017-09-20 at 12 35 46" src="https://user-images.githubusercontent.com/194511/30641781-42be3e0c-9e00-11e7-9224-79e16fe07998.png">

To restore tab functionality, swap `display: none` in the
`checkbox-group__input` for an `absolute` positioning within its div and an
opacity of 0 such that it responds once again to browser events.

Then style `:focus` the same as `:hover` for `.checkbox-group__input`, and
combine the styles for a selected focussed check box.