### PR TITLE
Fix links in preview returning to steps

### DIFF
--- a/app/helpers/research_sessions_helper.rb
+++ b/app/helpers/research_sessions_helper.rb
@@ -5,6 +5,6 @@ module ResearchSessionsHelper
     step_for_attr = ResearchSession::Steps.instance.attr_to_step(attr)
 
     link_to value,
-            research_session_question_path(@research_session, step_for_attr), class: 'editable'
+            research_session_question_path(@research_session.id, step_for_attr), class: 'editable'
   end
 end

--- a/spec/helpers/research_sessions_helper_spec.rb
+++ b/spec/helpers/research_sessions_helper_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe ResearchSessionsHelper, :type => :helper do
     before do
       allow(session).to receive(attr).and_return('Some attr value')
       allow(session).to receive(attr).with(:i_dont_exist).and_raise(NameError)
+      allow(session).to receive(:id).and_return(1234)
       @research_session = session
     end
 


### PR DESCRIPTION
# [BUG: Preview page links should return to the appropriate page of the Consent Form Builder for editing](https://trello.com/c/p6HAGJRa/176-bug-preview-page-links-should-return-to-the-appropriate-page-of-the-consent-form-builder-for-editing)

The rails `_path` method here *can* accept a model, but the trouble is
it's really getting a presenter that doesn't behave in quite the same
way. Since only the `ResearchSession#id` is used and the presenter already
has that, pass that through instead

(and update the test double to respond to `:id`)