### PR TITLE
Fix header width on mobile size viewports

### DIFF
--- a/app/assets/stylesheets/barnardos/_page.scss
+++ b/app/assets/stylesheets/barnardos/_page.scss
@@ -20,7 +20,7 @@
 }
 
 #global-header__logo {
-  margin-left: $gutter;
+  padding-left: $gutter;
 }
 
 #global-header__menu {


### PR DESCRIPTION
# [Header section causing horizontal scroll](https://trello.com/c/IukVaf3c/100-2-header-section-causing-horizontal-scroll)

On smaller viewports, the header was causing the page to overflow horizontally causing a scroll to black space. Adding the gutter space with padding allows the space to be contained within the width of the element.