### PR TITLE
Fix strong param error for blank checkboxes

### DIFF
--- a/app/controllers/research_sessions_controller.rb
+++ b/app/controllers/research_sessions_controller.rb
@@ -55,7 +55,10 @@ private
   end
 
   def question_params
-    params.require(:research_session).permit(ResearchSession::Steps::PARAMS[step])
+    params.require(:research_session).permit(ResearchSession::Steps::PARAMS[step]).tap do |p|
+      p['methodologies']&.reject!(&:blank?)
+      p['recording_methods']&.reject!(&:blank?)
+    end
   end
 end
 

--- a/app/helpers/barnardos/action_view/form_helper.rb
+++ b/app/helpers/barnardos/action_view/form_helper.rb
@@ -135,7 +135,7 @@ module Barnardos
           collection = collection.map { |k, v| [k.to_s, v] }
           concat(
             collection_check_boxes(
-              object_name, method, collection, :first, :last, include_hidden: false
+              object_name, method, collection, :first, :last
             ) do |b|
               content_tag :div, class: 'checkbox-group__choice' do
                 b.check_box(class: 'checkbox-group__input') +

--- a/app/javascript/components/conditional_subfields.js
+++ b/app/javascript/components/conditional_subfields.js
@@ -95,7 +95,7 @@ const ConditionalSubfields = {
    * Get the value that changed and decide if we should show
    * or hide the optional subfield.
    *
-   * If we hide the optional subfield, clear it's value also, so the form posts what the user expects
+   * If we hide the optional subfield, disable the field also, so the form posts what the user expects
    */
   _handleField (controlInput) {
     if (!controlInput) {
@@ -110,7 +110,7 @@ const ConditionalSubfields = {
     } else if (tagName === 'INPUT') {
       const type = controlInput.type
 
-      if (type === 'radio' || type === 'checkbox') {
+      if (type === 'radio' || type === 'checkbox' || type === 'hidden') {
         controlInputValue = Array
           .from(this.wrapper.querySelectorAll(`[name="${controlInput.name}"]:checked`))
           .map(input => input.value)

--- a/spec/controllers/research_sessions_controller_spec.rb
+++ b/spec/controllers/research_sessions_controller_spec.rb
@@ -56,8 +56,7 @@ describe ResearchSessionsController, type: :controller do
   end
 
   describe '#update' do
-    let(:existing_params) { {} }
-    let(:existing_session) { ResearchSession.create(existing_params) }
+    let(:existing_session) { create(existing_step) }
     subject(:research_session) do
       ResearchSession.find(existing_session.id)
     end
@@ -67,45 +66,37 @@ describe ResearchSessionsController, type: :controller do
     end
 
     context 'accepting methodologies' do
-      let(:existing_params) do
-        {
-          age: 'under18',
-          researcher_name: 'Alice',
-          researcher_phone: '0123456',
-          researcher_email: 'a@b.com',
-          topic: 'some topic',
-          purpose: 'some purppose'
-        }
-      end
+      let(:existing_step) { :purpose }
       let(:params) do
         {
           research_session_id: existing_session.id,
           id: 'methodologies',
-          research_session: { 'methodologies' => %w[interview usability] }
+          research_session: { 'methodologies' => ['', 'interview', 'usability'] }
         }
       end
 
-      it 'updates the research session' do
-        expect(research_session.methodologies).to eql(%w(interview usability))
+      it 'updates the research session, stripping the blank' do
+        expect(research_session.methodologies).to eql(%w[interview usability])
+      end
+    end
+
+    context 'accepting recording methods' do
+      let(:existing_step) { :methodologies }
+      let(:params) do
+        {
+          research_session_id: existing_session.id,
+          id: 'recording',
+          research_session: { 'recording_methods' => ['', 'audio', 'video'] }
+        }
+      end
+
+      it 'updates the research session, stripping the blank' do
+        expect(research_session.recording_methods).to eql(%w[audio video])
       end
     end
 
     context 'the last step' do
-      let(:existing_params) do
-        {
-          age: 'under12',
-          methodologies: %w(interview),
-          recording_methods: %w(audio),
-          topic: 'Some topic',
-          purpose: 'Some purpose',
-          researcher_name: 'Alice',
-          researcher_phone: '0123456',
-          researcher_email: 'a@b.com',
-          shared_with: 'team',
-          shared_duration: '1 Day',
-          shared_use: 'How to help people more'
-        }
-      end
+      let(:existing_step) { :data }
 
       let(:params) do
         {

--- a/spec/javascript/components/conditional_subfield_spec.js
+++ b/spec/javascript/components/conditional_subfield_spec.js
@@ -160,6 +160,42 @@ describe.only('Conditional subfields', () => {
       expect(document.getElementById('subfield-wrapper').className).to.include('is-active')
     })
 
+    it('should reveal that optional fragment on page load when a hidden field is present', () => {
+      const markup = `
+        <fieldset id="methodologies-wrapper" class="checkbox-group checkbox-group__vertical ">
+            <legend class="checkbox-group__legend">How will you be gathering information?</legend>
+            <input type="hidden" name="research_session[methodologies][]" value="">
+            <div><input type="checkbox" value="interview"
+                        checked="checked" name="research_session[methodologies][]"
+                        id="research_session_methodologies_interview">
+                <label for="research_session_methodologies_interview">Interview</label></div>
+            <div><input type="checkbox" value="usability"
+                        name="research_session[methodologies][]"
+                        id="research_session_methodologies_usability">
+                <label for="research_session_methodologies_usability">Usability testing</label></div>
+            <div><input type="checkbox" value="other"
+                        checked="checked" name="research_session[methodologies][]"
+                        id="research_session_methodologies_other">
+                <label for="research_session_methodologies_other">Other</label></div>
+        </fieldset>      
+        <div id="subfield-wrapper" class="js-ConditionalSubfield" data-controlled-by="research_session[methodologies][]"
+             data-control-value="other">
+            <div id="other_methodology-wrapper" class="textfield js-highlight-control ">
+                <label class="textfield__label" for="research_session_other_methodology">
+                    What is the other methodology?
+                </label>
+                <input class="textfield__input js-highlight-control__input " type="text"
+                       value="Things" name="research_session[other_methodology]"
+                       id="research_session_other_methodology"></div>
+        </div>        
+      `
+
+      const document = render(markup)
+      ConditionalSubfields.init(document)
+
+      expect(document.getElementById('subfield-wrapper').className).to.include('is-active')
+    })
+
     it('should mark a fragment visible with target value selected', () => {
       const markup = `
         <html>


### PR DESCRIPTION
# [BUG: If you don't select from a list of checkboxes when that's the only input, you get this error](https://trello.com/c/Yz48ihXf/177-3-bug-if-you-dont-select-from-a-list-of-checkboxes-when-thats-the-only-input-you-get-this-error)

<img width="971" alt="screen shot 2017-09-20 at 12 46 03" src="https://user-images.githubusercontent.com/194511/30685384-a4cfe706-9eac-11e7-9396-e11e76ce2477.png">

Fix the above, which is a 400 Bad Request resulting from an error thrown in `ResearchSessionsController#question_params` (the `permit` part) when no value is given for either of `methodologies` or `recording_method` due to no checkboxes being selected. 

What *should* happen is that the request is good but validation fails with a meaningful error message. What made this *not* happen is that we were using `include_hidden: false` as an option to `collection_check_boxes` to avoid a problem with `ConditionalSubfields.js` not being aware of hidden fields, overriding Rails' default behaviour and causing nothing to be passed when at least a blank value is required.

## To fix this:

1. Make `ConditionalSubfields.js` aware of blank hidden fields. This is good enough for our use case.
1. Remove the `include_hidden: false` option, allowing a blank value to be passed when no checkboxes are selected (and indeed, at every other time!)
1. Make `question_params` strip blank values for `methodologies` and `recording_methods` to avoid validation errors caused by blank values not being valid values for either.

## Also:

1. Make `research_sessions_controller_spec.rb` shorter by using the new `FactoryGirl` factories to construct test models up to a given point in the wizard.
