### PR TITLE
Improve session date time entry

### DIFF
--- a/app/views/research_sessions/time_equipment.html.erb
+++ b/app/views/research_sessions/time_equipment.html.erb
@@ -6,7 +6,11 @@
 
     <fieldset class="datefield" id="start_datetime">
       <legend class="datefield__label">Please enter the time and date of the session (optional)</legend>
-      <%= form.datetime_select :start_datetime %>
+      <%= form.datetime_select :start_datetime, {
+        :include_blank => true,
+        :default => nil,
+        minute_step: 15
+      } %>
     </fieldset>
 
     <%= form.labelled_text_field :duration %>


### PR DESCRIPTION
Make the session date and time truely optional
Change the minute dropdown to be in steps of 15 to make it easier to select.