### PR TITLE
Replace 'participants' with 'observers' on researcher page

### DIFF
--- a/app/views/research_sessions/researcher.html.erb
+++ b/app/views/research_sessions/researcher.html.erb
@@ -23,7 +23,7 @@
       <%= form.radio_group_vertical \
           :researcher_other,
           { false => 'No', true => 'Yes' },
-          legend: 'Will the participants meet any other researchers / participants?' %>
+          legend: 'Will the participants meet any other researchers / observers?' %>
 
       <div class="js-ConditionalSubfield" data-controlled-by="research_session[researcher_other]" data-control-value="true">
         <%= form.labelled_text_field :researcher_other_name %>


### PR DESCRIPTION
# [Researcher page: Last question should not read "/participant" it should say /secondary researcher or /observer](https://trello.com/c/vVxZhTh1/168-1-researcher-page-last-question-should-not-read-participant-it-should-say-secondary-researcher-or-observer)

Last question should not read "/ participants" it should say "/ observers"