### PR TITLE
Fix sass-lint warning

### DIFF
--- a/app/assets/stylesheets/barnardos/_print-section.scss
+++ b/app/assets/stylesheets/barnardos/_print-section.scss
@@ -22,7 +22,7 @@
     background-repeat: no-repeat;
     background-position: right $gutter center;
     background-size: 22px 22px;
-    padding: $gutter (22px + $gutter*2);
+    padding: $gutter (22px + $gutter * 2);
     margin: 0;
 
     @media (min-width: $tablet) {


### PR DESCRIPTION
Space around '*' required in _print-section.scss