### PR TITLE
Move to traits for ResearchSession factories

### DIFF
--- a/spec/controllers/research_sessions_controller_spec.rb
+++ b/spec/controllers/research_sessions_controller_spec.rb
@@ -56,7 +56,7 @@ describe ResearchSessionsController, type: :controller do
   end
 
   describe '#update' do
-    let(:existing_session) { create(existing_step) }
+    let(:existing_session) { create(:research_session, :"step_#{existing_step}") }
     subject(:research_session) do
       ResearchSession.find(existing_session.id)
     end

--- a/spec/factories/research_session.rb
+++ b/spec/factories/research_session.rb
@@ -1,46 +1,53 @@
 FactoryGirl.define do
   factory :research_session do
-    factory :researcher do
+    trait :step_researcher do
       status :researcher
       researcher_name 'Rachel Researcher'
       researcher_email 'r.researcher@barnardos.org.uk'
     end
 
-    factory :topic, parent: :researcher do
+    trait :step_topic do
+      step_researcher
       status :topic
       topic 'A topic'
     end
 
-    factory :purpose, parent: :topic do
+    trait :step_purpose do
+      step_topic
       status :purpose
       purpose 'A purpose'
     end
 
-    factory :methodologies, parent: :purpose do
+    trait :step_methodologies do
+      step_purpose
       status :methodologies
       methodologies %w[interview survey]
     end
 
-    factory :recording, parent: :methodologies do
+    trait :step_recording do
+      step_methodologies
       status :recording
       recording_methods %w[audio video]
     end
 
-    factory :data, parent: :recording do
+    trait :step_data do
+      step_recording
       status :data
       shared_with :team
       shared_duration '1 year'
       shared_use 'To train others'
     end
 
-    factory :time_equipment, parent: :data do
+    trait :step_time_equipment do
+      step_data
       status :time_equipment
       start_datetime DateTime.parse('1st Sep 2017')
       duration '1 week'
       participant_equipment 'A coat'
     end
 
-    factory :expenses, parent: :time_equipment do
+    trait :step_expenses do
+      step_time_equipment
       status :expenses
       travel_expenses_limit '10.00'
       food_expenses_limit '20.00'
@@ -49,7 +56,8 @@ FactoryGirl.define do
       food_provided 'Light canapés'
     end
 
-    factory :incentive, parent: :expenses do
+    trait :step_incentive do
+      step_expenses
       status :incentive
       incentive true
       payment_type :cash

--- a/spec/models/research_session_spec.rb
+++ b/spec/models/research_session_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ResearchSession, type: :model do
       before do
         session.status = step
         if step != :new
-          attrs = attributes_for(step)
+          attrs = attributes_for(:research_session, "step_#{step}".to_sym)
           session.assign_attributes(attrs.merge(set_attrs))
         end
         session.validate

--- a/spec/presenters/research_session_presenter_spec.rb
+++ b/spec/presenters/research_session_presenter_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe ResearchSessionPresenter do
     end
 
     context 'expenses given' do
-      let(:research_session) { build_stubbed :expenses }
+      let(:research_session) { build_stubbed :research_session, :step_expenses }
       it { is_expected.to be true }
     end
   end
@@ -129,14 +129,14 @@ RSpec.describe ResearchSessionPresenter do
 
     context 'One expense is given' do
       let(:research_session) do
-        build_stubbed :time_equipment, travel_expenses_limit: 50.00
+        build_stubbed :research_session, :step_time_equipment, travel_expenses_limit: 50.00
       end
       it { is_expected.to eql('We allow travel expenses of up to £50.00.') }
     end
 
     context 'Two expenses are given' do
       let(:research_session) do
-        build_stubbed :time_equipment,
+        build_stubbed :research_session, :step_time_equipment,
                       travel_expenses_limit: 50.00,
                       food_expenses_limit: 10.00
       end
@@ -149,7 +149,7 @@ RSpec.describe ResearchSessionPresenter do
 
     context 'Three expenses are given' do
       let(:research_session) do
-        build_stubbed :time_equipment,
+        build_stubbed :research_session, :step_time_equipment,
                       travel_expenses_limit: 50.00,
                       food_expenses_limit: 10.00,
                       other_expenses_limit: 5.00
@@ -167,7 +167,7 @@ RSpec.describe ResearchSessionPresenter do
     subject(:text) { presenter.incentive_text }
 
     context 'no incentive is given' do
-      let(:research_session) { build_stubbed :incentive, incentive: false }
+      let(:research_session) { build_stubbed :research_session, :step_incentive, incentive: false }
       it { is_expected.to be_empty }
     end
 
@@ -176,7 +176,7 @@ RSpec.describe ResearchSessionPresenter do
     end
 
     context 'a cash incentive is provided' do
-      let(:research_session) { build_stubbed :incentive }
+      let(:research_session) { build_stubbed :research_session, :step_incentive }
       it 'has a message about the cash value' do
         expect(text).to eql(
           "a cash incentive of £#{formatted_value}"
@@ -185,7 +185,9 @@ RSpec.describe ResearchSessionPresenter do
     end
 
     context 'a high street voucher incentive is provided' do
-      let(:research_session) { build_stubbed :incentive, payment_type: 'voucher' }
+      let(:research_session) do
+        build_stubbed :research_session, :step_incentive, payment_type: 'voucher'
+      end
       it 'has a message about the high street voucher value' do
         expect(text).to eql(
           "high street vouchers to the value of £#{formatted_value}"


### PR DESCRIPTION
So far, we've had one solitary set of factories registered with the
same names as all the steps, namely:

* `:researcher`
* `:topic`
* `:purpose` .. and so on, with each factory dependent on the previous.

Now we need an actual `:researcher` factory for ([this story](https://trello.com/c/kpHLeXSK/122-5-add-another-researcher)), that `:researcher`
registered factory name needs to move.

Take the opportunity to move to traits.

## Before

`build_stubbed :researcher` – would return a `ResearchSession` with a
status valid at the `:researcher` step and the researcher details
filled in

## After

`build_stubbed :research_session, :step_researcher` – will return a
`ResearchSession` with a status of `:researcher` and the researcher
details filled in. No longer misleading!