### PR TITLE
Stop rendering views in controller spec

### DIFF
--- a/spec/controllers/research_sessions_controller_spec.rb
+++ b/spec/controllers/research_sessions_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 describe ResearchSessionsController, type: :controller do
-  render_views
-
   describe '#create' do
     it 'redirects to the first question' do
       post :create
@@ -30,7 +28,7 @@ describe ResearchSessionsController, type: :controller do
           expect(response).to be_ok
         end
         it 'renders a template for the id given' do
-          expect(response.body).to include('How will you be gathering information?')
+          expect(response.body).to render_template('methodologies')
         end
       end
 


### PR DESCRIPTION
Was slow (manifested in first test hanging for seconds) and has been unnecessary for a while. We don't care what was rendered, just that the right template was chosen.