### PR TITLE
Fix fields for formbuilder

### DIFF
--- a/app/helpers/barnardos/action_view/form_builder.rb
+++ b/app/helpers/barnardos/action_view/form_builder.rb
@@ -19,15 +19,17 @@ module Barnardos
         )
       end
 
-      def radio_group_vertical(method, collection, legend: nil, legend_options: {})
+      def radio_group_vertical(method, collection, options = {}, legend: nil, legend_options: {})
         @template.radio_group_vertical(
-          @object_name, method, collection, legend: legend, legend_options: legend_options
+          @object_name, method, collection, objectify_options(options),
+          legend: legend, legend_options: legend_options
         )
       end
 
-      def checkbox_group_vertical(method, collection, legend: nil, legend_options: {})
+      def checkbox_group_vertical(method, collection, options = {}, legend: nil, legend_options: {})
         @template.checkbox_group_vertical(
-          @object_name, method, collection, legend: legend, legend_options: legend_options
+          @object_name, method, collection, objectify_options(options),
+          legend: legend, legend_options: legend_options
         )
       end
     end

--- a/app/helpers/barnardos/action_view/form_builder.rb
+++ b/app/helpers/barnardos/action_view/form_builder.rb
@@ -2,6 +2,8 @@ module Barnardos
   module ActionView
     class FormBuilder < ::ActionView::Helpers::FormBuilder
       def labelled_text_field(method, text = nil, text_options: {}, label_options: {}, &block)
+        text_options = objectify_options(text_options)
+        text_options.delete(:skip_default_ids)
         @template.labelled_text_field(
           @object_name, method, text, text_options: text_options,
                                       label_options: label_options, &block
@@ -9,6 +11,8 @@ module Barnardos
       end
 
       def labelled_text_area(method, label: nil, label_options: {}, text_options: {})
+        text_options = objectify_options(text_options)
+        text_options.delete(:skip_default_ids)
         @template.labelled_text_area(
           @object_name, method, label: label,
                                 label_options: label_options, text_options: text_options

--- a/app/helpers/barnardos/action_view/form_helper.rb
+++ b/app/helpers/barnardos/action_view/form_helper.rb
@@ -85,7 +85,9 @@ module Barnardos
         end
       end
 
-      def radio_group_vertical(object, method, collection, legend: nil, legend_options: {})
+      def radio_group_vertical(
+        object, method, collection, options = {}, legend: nil, legend_options: {}
+      )
         wrapper_tag object, method, tag: :fieldset, class: 'radio-group radio-group__vertical' do
           next unless collection.any?
 
@@ -103,7 +105,7 @@ module Barnardos
 
           collection = Array(collection)
           buttons = collection_radio_buttons(
-            object, method, collection, :first, :last, include_hidden: false
+            object, method, collection, :first, :last, options
           ) do |b|
             content_tag :div, class: 'radio-group__choice' do
               b.radio_button(class: 'radio-group__input') +
@@ -115,7 +117,9 @@ module Barnardos
         end
       end
 
-      def checkbox_group_vertical(object_name, method, collection, legend: nil, legend_options: {})
+      def checkbox_group_vertical(
+        object_name, method, collection, options = {}, legend: nil, legend_options: {}
+      )
         wrapper_tag(
           object_name, method,
           tag: :fieldset, class: 'checkbox-group checkbox-group__vertical'
@@ -139,7 +143,7 @@ module Barnardos
           collection = collection.map { |k, v| [k.to_s, v] }
           concat(
             collection_check_boxes(
-              object_name, method, collection, :first, :last
+              object_name, method, collection, :first, :last, options
             ) do |b|
               content_tag :div, class: 'checkbox-group__choice' do
                 b.check_box(class: 'checkbox-group__input') +

--- a/spec/helpers/barnardos/action_view/form_builder_spec.rb
+++ b/spec/helpers/barnardos/action_view/form_builder_spec.rb
@@ -9,9 +9,10 @@ RSpec.describe Barnardos::ActionView::FormBuilder do
 
   let(:helper)  { TestHelperCarrier.new }
   let(:builder) { Barnardos::ActionView::FormBuilder.new(:research_session, model, helper, {}) }
-  let(:model)   { ResearchSession.new topic: 'somevalue' }
 
   describe '#labelled_text_field' do
+    let(:model) { ResearchSession.new topic: 'somevalue' }
+
     subject(:rendered) { builder.labelled_text_field(:topic) }
 
     it 'populates values as it should' do
@@ -24,6 +25,8 @@ RSpec.describe Barnardos::ActionView::FormBuilder do
   end
 
   describe '#labelled_text_area' do
+    let(:model) { ResearchSession.new topic: 'somevalue' }
+
     subject(:rendered) { builder.labelled_text_area(:topic) }
 
     it 'populates values as it should' do
@@ -32,6 +35,54 @@ RSpec.describe Barnardos::ActionView::FormBuilder do
 
     it 'preserves default ids so that labels work' do
       expect(rendered).to have_tag('textarea[id=research_session_topic]')
+    end
+  end
+
+  describe '#checkbox_group_vertical' do
+    let(:model) { ResearchSession.new methodologies: %w[interview audio] }
+
+    let(:collection) do
+      {
+        interview: 'Interview',
+        audio: 'Audio',
+        other: 'Other'
+      }
+    end
+
+    subject(:rendered) do
+      builder.checkbox_group_vertical(:methodologies, collection)
+    end
+
+    it 'selects values checked on the model' do
+      expect(rendered).to have_tag('input[value=interview][checked]')
+      expect(rendered).to have_tag('input[value=audio][checked]')
+    end
+    it 'does not select values unchecked on the model' do
+      expect(rendered).to have_tag('input:not(checked)[value=other]')
+    end
+  end
+
+  describe '#radio_group_vertical' do
+    let(:model) { ResearchSession.new shared_with: 'team' }
+
+    let(:collection) do
+      {
+        team:     'Just the team',
+        internal: 'Other teams internally',
+        external: 'Other teams externally'
+      }
+    end
+
+    subject(:rendered) do
+      builder.radio_group_vertical(:shared_with, collection)
+    end
+
+    it 'selects the value checked on the model' do
+      expect(rendered).to have_tag('input[value=team][checked]')
+    end
+    it 'does not select values unchecked on the model' do
+      expect(rendered).to have_tag('input:not(checked)[value=internal]')
+      expect(rendered).to have_tag('input:not(checked)[value=external]')
     end
   end
 end

--- a/spec/helpers/barnardos/action_view/form_builder_spec.rb
+++ b/spec/helpers/barnardos/action_view/form_builder_spec.rb
@@ -1,4 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe Barnardos::ActionView::FormBuilder do
+  include RSpecHtmlMatchers
+
+  class TestHelperCarrier < ActionView::Base
+    include Barnardos::ActionView::FormHelper
+  end
+
+  let(:helper)  { TestHelperCarrier.new }
+  let(:builder) { Barnardos::ActionView::FormBuilder.new(:research_session, model, helper, {}) }
+  let(:model)   { ResearchSession.new topic: 'somevalue' }
+
+  describe '#labelled_text_field' do
+    subject(:rendered) { builder.labelled_text_field(:topic) }
+
+    it 'populates values as it should' do
+      expect(rendered).to have_tag('input[value=somevalue]')
+    end
+
+    it 'preserves default ids so that labels work' do
+      expect(rendered).to have_tag('input[id=research_session_topic]')
+    end
+  end
+
+  describe '#labelled_text_area' do
+    subject(:rendered) { builder.labelled_text_area(:topic) }
+
+    it 'populates values as it should' do
+      expect(rendered).to have_tag('textarea', text: /somevalue/)
+    end
+
+    it 'preserves default ids so that labels work' do
+      expect(rendered).to have_tag('textarea[id=research_session_topic]')
+    end
+  end
 end


### PR DESCRIPTION
# [BUG: fields not populated correctly under `fields_for`](https://trello.com/c/LMt5EzSE/183-3-bug-fields-not-populated-correctly-under-fieldsfor)
Because of [this branch](https://trello.com/c/kpHLeXSK/122-5-add-another-researcher), we found that in some circumstances – chiefly when using `fields_for` – our `barnardos_form_with` fields weren't having their values populated when returning to wizard steps.

We discovered that it's the responsibility of a `FormBuilder` to call `objectify_options` on a vanilla `options` hash passed to underlying Rails tag generators such that when we can't simply send an attribute name to a named model (because, for example, we're in a nested object in a `fields_for` block), Rails can consult the `options` hash to discover an object from which it can populate the value.

For each of our four methods, ensure this `options` hash is routed to the correct Rails helper. In the case of the two text field types, that means sending an objectified `text_options` to the `text_field` or `text_area` methods.

In the case of the checkbox and radio group types, that means sending a new vanilla `options` parameter to `collection_check_boxes` and `collection_radio_buttons`.

## Before:

<img width="353" alt="screen shot 2017-09-27 at 11 50 13" src="https://user-images.githubusercontent.com/194511/30909763-28f09590-a37a-11e7-8805-76644dea987e.png">


## After:

<img width="379" alt="screen shot 2017-09-27 at 11 50 23" src="https://user-images.githubusercontent.com/194511/30909771-2f5c9942-a37a-11e7-9779-11caf19ccbec.png">
