### PR TITLE
Add reference to child for respondents who cant give consent

### DIFF
--- a/app/helpers/research_sessions_helper.rb
+++ b/app/helpers/research_sessions_helper.rb
@@ -7,4 +7,12 @@ module ResearchSessionsHelper
     link_to value,
             research_session_question_path(@research_session.id, step_for_attr), class: 'editable'
   end
+
+  def you_or_your_child
+    @research_session.able_to_consent? ? 'you' : 'your child/the child in your care'
+  end
+
+  def you_or_they
+    @research_session.able_to_consent? ? 'you' : 'they'
+  end
 end

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -66,23 +66,22 @@
       <%= @research_session.methodology_list %>
     <% end %>
     <p>
-      With your permission we will record <%= @research_session.unable_to_consent? ? 'your childʼs/the childʼs in your care' : 'the' %> session using
+      With your permission we will record <%= @research_session.unable_to_consent? ? 'your childʼs/the child in your care‘s' : 'the' %> session using
       <%= edit_link_for(:recording_methods) { @research_session.recording_methods_list } %>.
       Recording the session helps the researcher and other research team members
       trying to improve the service, as it allows them to review the most useful
-      parts of the session after it hasfinished.
+      parts of the session after it has finished.
     </p>
   </section>
   <section>
     <h3 class="subtitle-small" id="doi">Do I have to take part?</h3>
     <p>
       Taking part is entirely voluntary - it is up to you to decide whether or not <%= you_or_your_child %>
-      to take part. If you decide  <%= 'your child/the child in your care' if @research_session.unable_to_consent? %> to take part <%= you_or_they %> do not have to answer questions
-      <%= you_or_they %> do not want to answer. <%= you_or_they.capitalize %> can also change <%= @research_session.able_to_consent? ? 'your' : 'their' %> mind about taking part
+      should take part. If you decide <%= you_or_your_child %> should take part <%= you_or_they %> do not have to answer questions <%= you_or_they %> do not want to answer. <%= you_or_they.capitalize %> can also change <%= @research_session.able_to_consent? ? 'your' : 'their' %> mind about taking part
       at any time and withdraw without giving a reason.
     </p>
     <p>
-      If you agree <%= 'for your childʼs/the childʼs in your care' if @research_session.unable_to_consent? %> to take part, you will be given a copy of this information
+      If you agree <%= 'for your child/the child in your care' if @research_session.unable_to_consent? %> to take part, you will be given a copy of this information
       sheet and be asked to sign a consent form.
     </p>
   </section>

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -24,7 +24,7 @@
   <section>
     <h2 class="heading-medium">About this research project</h2>
     <p class="super-text">This information sheet will tell you more about the
-    research so that you can decide whether or not you would like to take part.</p>
+    research so that you can decide whether or not <%= you_or_your_child %> would like to take part.</p>
   </section>
 
   <section>
@@ -44,7 +44,7 @@
 
     <p>
       It is important that we test the current and future tools and services that
-      we are developing with people like you so that we can make them as good as
+      we are developing with people like <%= you_or_your_child %> so that we can make them as good as
       possible.
     </p>
   </section>
@@ -66,7 +66,7 @@
       <%= @research_session.methodology_list %>
     <% end %>
     <p>
-      With your permission we will record the session using
+      With your permission we will record <%= @research_session.unable_to_consent? ? 'your childʼs/the childʼs in your care' : 'the' %> session using
       <%= edit_link_for(:recording_methods) { @research_session.recording_methods_list } %>.
       Recording the session helps the researcher and other research team members
       trying to improve the service, as it allows them to review the most useful
@@ -76,13 +76,13 @@
   <section>
     <h3 class="subtitle-small" id="doi">Do I have to take part?</h3>
     <p>
-      Taking part is entirely voluntary - it is up to you to decide whether or not
-      to take part. If you decide to take part you do not have to answer questions
-      you do not want to answer. You can also change your mind about taking part
+      Taking part is entirely voluntary - it is up to you to decide whether or not <%= you_or_your_child %>
+      to take part. If you decide  <%= 'your child/the child in your care' if @research_session.unable_to_consent? %> to take part <%= you_or_they %> do not have to answer questions
+      <%= you_or_they %> do not want to answer. <%= you_or_they.capitalize %> can also change <%= @research_session.able_to_consent? ? 'your' : 'their' %> mind about taking part
       at any time and withdraw without giving a reason.
     </p>
     <p>
-      If you agree to take part, you will be given a copy of this information
+      If you agree <%= 'for your childʼs/the childʼs in your care' if @research_session.unable_to_consent? %> to take part, you will be given a copy of this information
       sheet and be asked to sign a consent form.
     </p>
   </section>
@@ -102,7 +102,7 @@
       edit and share insights relevant to the project. Whenever we share these
       insights, the material is fully anonymised and contributions cannot be
       attributed to named individuals.</p>
-    <p>You will not be identifiable in anything published. All personal data
+    <p><%= you_or_your_child.capitalize %> will not be identifiable in anything published. All personal data
       collected as part of the research is stored securely and kept strictly
       confidential.</p>
   </section>
@@ -114,7 +114,7 @@
   </section>
   <% if @research_session.start_datetime.present? or @research_session.duration.present? %>
     <section>
-      <h3 class="subtitle-small" id="private">When is the session and what should I bring?</h3>
+      <h3 class="subtitle-small" id="private">When is the session and what should <%= @research_session.able_to_consent? ? 'I' : 'my child/the child in my care' %> bring?</h3>
         <p>
           <% if @research_session.start_datetime %>
             The session is on

--- a/spec/views/research_session/preview.html.erb_spec.rb
+++ b/spec/views/research_session/preview.html.erb_spec.rb
@@ -10,7 +10,6 @@ describe 'research_sessions/preview' do
     stub_template 'research_sessions/_progress' => '<%= NOT RENDERED %>'
     render
   end
-
   context 'no date or duration is given' do
     let(:extra_attrs) { { start_datetime: nil, duration: nil } }
 
@@ -40,6 +39,38 @@ describe 'research_sessions/preview' do
 
     it 'does not show the duration' do
       expect(rendered).not_to match(/The session will last for/m)
+    end
+  end
+
+  context 'the participant is able to give consent' do
+    let(:extra_attrs) { { age: 'over18' } }
+
+    it 'phrases blocks using "you"' do
+      expect(rendered).to have_content(
+        <<~TEXT
+          Taking part is entirely voluntary -
+          it is up to you to decide whether or not you should take part.
+          If you decide you should take part you do not have to answer
+          questions you do not want to answer. You can also change your mind about taking part
+          at any time and withdraw without giving a reason.
+        TEXT
+      )
+    end
+  end
+
+  context 'the participant is not able to give consent' do
+    let(:extra_attrs) { { age: 'under18' } }
+
+    it 'phrases blocks using "your child"' do
+      expect(rendered).to have_content(
+        <<~TEXT
+          Taking part is entirely voluntary -
+          it is up to you to decide whether or not your child/the child in your care should take part.
+          If you decide your child/the child in your care should take part they do not have to answer
+          questions they do not want to answer. They can also change their mind about taking part
+          at any time and withdraw without giving a reason.
+        TEXT
+      )
     end
   end
 end


### PR DESCRIPTION
# [Dynamic Preview Copy - Can or Can't give consent](https://trello.com/c/uexOizmX/146-dynamic-preview-copy-can-or-cant-give-consent)

The info sheet only refers to the reader as the participant/respondent.
Adding in conditional copy that makes it clear who the participant is
and what the research is asking of them depending if they can give
consent.

Will run through with Jess to ensure it makes sense. Can you see any other bits that might be missing?