### PR TITLE
Add another

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,6 +10,7 @@
 @import "barnardos/datefield";
 @import "barnardos/errorsummary";
 @import "barnardos/fieldset";
+@import "barnardos/fieldset-list";
 @import "barnardos/page";
 @import "barnardos/print-section";
 @import "barnardos/progress";

--- a/app/assets/stylesheets/barnardos/_button.scss
+++ b/app/assets/stylesheets/barnardos/_button.scss
@@ -65,6 +65,32 @@
   }
 }
 
+.button--danger {
+  background-color: $error-colour;
+  border-color: $grey-dark;
+
+  &:visited,
+  &:link {
+    color: $grey-dark;
+    text-decoration: none;
+  }
+
+  &:active {
+    background-color: $grey-dark;
+    border-color: $grey-dark;
+    color: $white;
+  }
+
+  @media (min-width: $tablet) {
+    &:hover,
+    &:focus {
+      background-color:  $grey-dark;
+      border-color:  $grey-dark;
+      color: $white;
+    }
+  }
+}
+
 .button-bar {
   display: block;
   margin: (4 * $gutter) 0;

--- a/app/assets/stylesheets/barnardos/_fieldset-list.scss
+++ b/app/assets/stylesheets/barnardos/_fieldset-list.scss
@@ -1,0 +1,15 @@
+.fieldset-list {
+  .fieldset {
+    legend {
+      margin-bottom: 0;
+    }
+
+    .textfield {
+      margin-top: 0;
+    }
+
+    padding-bottom: $gutter;
+    margin-bottom: $gutter;
+    border-bottom: $border 1px solid;
+  }
+}

--- a/app/controllers/research_sessions_controller.rb
+++ b/app/controllers/research_sessions_controller.rb
@@ -14,12 +14,15 @@ class ResearchSessionsController < ApplicationController
   end
 
   def create
-    session_id = ResearchSession.create.id
-    redirect_to(first_question_path(session_id))
+    session = ResearchSession.create
+    redirect_to(first_question_path(session.id))
   end
 
   def show
     @research_session = current_research_session
+    if (step == :researcher) && @research_session.researchers.none?
+      @research_session.researchers.build
+    end
     render_wizard
   end
 
@@ -38,6 +41,7 @@ class ResearchSessionsController < ApplicationController
     @research_session = current_research_session
     @research_session.status = step
     @research_session.assign_attributes(question_params)
+    @research_session.save
     render_wizard @research_session
   end
 

--- a/app/javascript/components/add_another.js
+++ b/app/javascript/components/add_another.js
@@ -1,0 +1,210 @@
+const assign = require('lodash/assign')
+const pickBy = require('lodash/pickBy')
+
+const {
+  insertAfter,
+  resetFieldValues,
+  regenIds,
+  closest,
+  removeElement
+} = require('../lib/element_helpers')
+
+const addButtonClass = 'js-AddItems__add'
+const removeButtonClass = 'js-AddItems__remove'
+
+/**
+ * AddAnother
+ *
+ * Module that scans markup to find elements that require a 'add another' functionality
+ * The target element defines a selector to define what page fragment should be duplicated.
+ *
+ * Settings can be passed using data attributes to customise how the module behaves:
+ *
+ * @param {boolean} [canRemoveAll=false] - Whether all items can be removed
+ * @param {string} [itemSelector='.js-AddItems__item'] - The piece of HTML that should be duplicated
+ * @param {string} [itemName='item'] - Name to use when adding/removing items
+ * @param {string} [addButtonSelector='.js-AddItems__add'] - Selector for adding items. If one cannot be found a button will be added
+ * @param {string} [addButtonText='Add another {{itemName}}'] - Text template to use for add button. `{{itemName}}` can be used to position the name of the item
+ * @param {string} [removeButtonSelector='.js-AddItems__remove'] - Selector for removing items. If one cannot be found a button will be added to each item
+ * @param {string} [removeButtonText='Remove'] - Text template to use for remove button. `{{itemName}}` can be used to position the name of the item
+ *
+ * @example
+ * <div class="js-AddAnother"
+ *   data-item-selector=".js-researcher"
+ *   data-item-name="researcher"
+ * >
+ *   <fieldset class="fieldset js-researcher">
+ *     <legend>Researcher</legend>
+ *     <div id="researcher_name-wrapper" class="textfield js-highlight-control">
+ *       <label class="textfield__label " for="research_session_researchers_attributes_0_researcher_name">Full name</label>
+ *       <input class="textfield__input js-highlight-control__input " type="text" name="research_session[researchers_attributes][0][researcher_name]" id="research_session_researchers_attributes_0_researcher_name">
+ *     </div>
+ *     <div id="researcher_phone-wrapper" class="textfield js-highlight-control ">
+ *       <label class="textfield__label " for="research_session_researchers_attributes_0_researcher_phone">Telephone number (optional)</label>
+ *       <input class="textfield__input js-highlight-control__input " type="text" name="research_session[researchers_attributes][0][researcher_phone]" id="research_session_researchers_attributes_0_researcher_phone">
+ *     </div>
+ *     <div id="researcher_email-wrapper" class="textfield js-highlight-control ">
+ *       <label class="textfield__label " for="research_session_researchers_attributes_0_researcher_email">Email</label>
+ *       <input class="textfield__input js-highlight-control__input " type="text" name="research_session[researchers_attributes][0][researcher_email]" id="research_session_researchers_attributes_0_researcher_email">
+ *     </div>
+ *   </fieldset>
+ * </div>
+ */
+const AddAnother = {
+  defaults: {
+    canRemoveAll: false,
+    itemSelector: '.js-AddItems__item',
+    itemName: 'item',
+    addButtonSelector: `.${addButtonClass}`,
+    addButtonText: 'Add another {{itemName}}',
+    removeButtonSelector: `.${removeButtonClass}`,
+    removeButtonText: 'Remove'
+  },
+
+  init (wrapper = document, options) {
+    this.wrapper = wrapper
+    this.settings = assign({}, this.defaults, options)
+
+    this.cacheEls()
+    this.bindEvents()
+    this.render()
+  },
+
+  cacheEls () {
+    const lastItem = this.wrapper.querySelector(this.settings.itemSelector)
+
+    this.itemContainer = lastItem.parentNode
+    this.template = lastItem.cloneNode(true)
+    this.addButton = this.wrapper.querySelector(this.settings.addButtonSelector)
+  },
+
+  bindEvents () {
+    this.wrapper.addEventListener('click', this.clickHandler.bind(this))
+  },
+
+  render () {
+    this.insertAddButton()
+    this.insertRemoveButtons()
+
+    this.decorateButtons()
+    this.updateButtonState()
+  },
+
+  decorateButtons () {
+    const removeButtons = Array.from(this.wrapper.querySelectorAll(this.settings.removeButtonSelector))
+    const addButton = this.addButton
+
+    if (addButton) {
+      addButton.setAttribute('data-method', 'add')
+    }
+
+    removeButtons.forEach((element) => {
+      element.setAttribute('data-method', 'remove')
+      element.innerHTML = this.settings.removeButtonText.replace('{{itemName}}', this.settings.itemName)
+    })
+  },
+
+  insertAddButton () {
+    if (this.addButton) {
+      return
+    }
+
+    const addButtonElement = this.document.createElement('button')
+    addButtonElement.setAttribute('type', 'button')
+    addButtonElement.className = 'button button--secondary'
+    addButtonElement.innerText = `Add another ${this.settings.itemName}`
+    addButtonElement.setAttribute('data-method', 'add')
+    this.addButton = addButtonElement
+
+    const addButtonWrapper = this.document.createElement('p')
+    addButtonWrapper.className = 'form-group'
+    addButtonWrapper.appendChild(addButtonElement)
+
+    this.wrapper.appendChild(addButtonWrapper)
+  },
+
+  insertRemoveButtons () {
+    Array.from(this.wrapper.querySelectorAll(this.settings.itemSelector))
+      .forEach((item) => {
+        if (item.querySelector(this.settings.removeButtonSelector)) {
+          return
+        }
+
+        const removeButtonElement = this.document.createElement('button')
+        removeButtonElement.className = `button button--danger ${removeButtonClass}`
+
+        item.appendChild(removeButtonElement)
+      })
+  },
+
+  updateButtonState () {
+    const removeButtons = Array.from(this.wrapper.querySelectorAll(this.settings.removeButtonSelector))
+
+    if (removeButtons.length === 1 && !this.settings.canRemoveAll) {
+      removeElement(removeButtons[0])
+    }
+  },
+
+  clickHandler (event) {
+    const target = event.target
+
+    if (!target.hasAttribute('data-method')) {
+      return
+    }
+
+    switch (target.getAttribute('data-method')) {
+      case 'add':
+        this.addItem()
+        break
+      case 'remove':
+        const element = closest(target, this.settings.itemSelector)
+        this.removeItem(element)
+        break
+    }
+
+    event.preventDefault()
+    this.render()
+  },
+
+  addItem () {
+    const lastItem = this.wrapper.querySelector(`${this.settings.itemSelector}:last-of-type`)
+    const newItem = regenIds(this.template.cloneNode(true))
+
+    resetFieldValues(newItem)
+
+    if (!lastItem) {
+      return this.itemContainer.appendChild(newItem)
+    }
+
+    insertAfter(newItem, lastItem)
+  },
+
+  removeItem (item) {
+    item.parentNode.removeChild(item)
+  }
+}
+
+module.exports = {
+  init (page = document) {
+    const elements = Array.from(page.querySelectorAll('.js-AddAnother'))
+
+    elements.forEach((element) => {
+      const settings = {
+        canRemoveAll: element.hasAttribute('data-can-remove-all'),
+        itemSelector: element.getAttribute('data-item-selector'),
+        itemName: element.getAttribute('data-item-name'),
+        addButtonSelector: element.getAttribute('data-add-button-selector'),
+        addButtonText: element.getAttribute('data-add-button-text'),
+        removeButtonSelector: element.getAttribute('data-remove-button-selector'),
+        removeButtonText: element.getAttribute('data-remove-button-text')
+      }
+
+      const addAnother = Object.create(AddAnother, {
+        document: {
+          value: page
+        }
+      })
+      addAnother.init(element, pickBy(settings))
+    })
+  }
+}

--- a/app/javascript/lib/element_helpers.js
+++ b/app/javascript/lib/element_helpers.js
@@ -1,3 +1,7 @@
+/* eslint no-useless-escape: 0 */
+const regularExp1 = '(\\s|^)'
+const regularExp2 = '(\\s|$)'
+
 function addClass (element, className) {
   if (!element) return
   if (isNodeList(element)) {
@@ -20,20 +24,44 @@ function removeClass (element, className) {
   } else if (element.classList) {
     element.classList.remove(className)
   } else if (hasClass(element, className)) {
-    const regClass = new RegExp(`(\\s|^)${className}(\\s|$`)
+    const regClass = new RegExp(regularExp1 + className + regularExp2)
     element.className = element.className.replace(regClass, ' ')
   }
 }
 
 function hasClass (element, className) {
-  if (!element) {
-    return false
-  }
-
+  if (!element) return
   if (element.classList) {
     return element.classList.contains(className)
   }
-  return element.className.match(new RegExp(`(\\s|^)${className}(\\s|$`))
+  return element.className.match(new RegExp(regularExp1 + className + regularExp2))
+}
+
+function toggleClass (element, className) {
+  if (!element) return
+  if (isNodeList(element)) {
+    for (let pos = element.length - 1; pos > -1; pos -= 1) {
+      toggleClass(element.item(pos), className)
+    }
+  } else if (hasClass(element, className)) {
+    removeClass(element, className)
+  } else {
+    addClass(element, className)
+  }
+}
+
+/**
+ * generateId
+ *
+ * Create an ID string unique enough to use as an element ID in a page.
+ * The prefix is required as ID's cannot start with a number or a hyphen
+ *
+ * @param {string} prefix
+ * @returns {string} a unique string to use to indentify an element
+ */
+function generateID (prefix) {
+  const _prefix = (prefix && prefix.length > 0) ? prefix : 'dh'
+  return `${_prefix}-${Math.floor(Math.random() * 1000000) + 1}`
 }
 
 function isNodeList (nodes) {
@@ -45,8 +73,154 @@ function isNodeList (nodes) {
     (nodes.length === 0 || (typeof nodes[0] === 'object' && nodes[0].nodeType > 0))
 }
 
+function findDoc (el) {
+  while (el.parentNode) {
+    el = el.parentNode
+  }
+  return el
+}
+
+function insertAfter (newElement, targetElement) {
+  // target is what you want it to go after. Look for this elements parent.
+  const parent = targetElement.parentNode
+
+  // if the parents lastchild is the targetElement...
+  if (parent.lastChild === targetElement) {
+    // add the newElement after the target element.
+    parent.appendChild(newElement)
+  } else {
+    // else the target has siblings, insert the new element between the target and it's next sibling.
+    parent.insertBefore(newElement, targetElement.nextSibling)
+  }
+}
+
+function hide (element) {
+  addClass(element, 'u-hidden')
+  element.setAttribute('aria-hidden', true)
+}
+
+function show (element) {
+  removeClass(element, 'u-hidden')
+  element.setAttribute('aria-hidden', false)
+}
+
+function createElementFromMarkup (markup, docToCreateIn) {
+  const documentRef = docToCreateIn || document
+  let tmp = documentRef.createElement('body')
+  tmp.innerHTML = markup
+  return tmp.firstElementChild
+}
+
+function removeElement (element) {
+  if (!element) return
+  element.parentNode.removeChild(element)
+}
+
+/**
+ * resetFieldValues
+ *
+ * Scans the content of a dom fragment for fields
+ * and resets their values back to nothing.
+ *
+ * Useful when copying fields to use as new fields
+ *
+ * @param {nodeElement} fragment
+ *
+ * @returns {nodeElement}
+ */
+function resetFieldValues (element) {
+  Array.from(element.querySelectorAll('option:checked'))
+    .forEach(selectedElement => {
+      selectedElement.selected = false
+    })
+
+  Array.from(element.querySelectorAll('input:checked'))
+    .forEach(checkedElement => {
+      checkedElement.checked = false
+    })
+
+  Array.from(element.querySelectorAll('input[type="text"], textarea'))
+    .forEach(textField => {
+      textField.value = ''
+    })
+
+  Array.from(element.querySelectorAll('select'))
+    .forEach(field => {
+      field.selectedIndex = 0
+    })
+
+  return element
+}
+
+/**
+ * regenIds
+ * *
+ * Get all the all the elements in a fragment that have an ID
+ * attribute, generate a new one to replace it and look for related
+ * label tags to update their 'for' attribute
+ *
+ * @param {nodeElement} wrapper
+ *
+ * @returns {nodeElement}
+ */
+function regenIds (wrapper) {
+  Array
+    .from(wrapper.querySelectorAll('*[id]'))
+    .forEach((element) => {
+      const oldId = element.id
+
+      // If the element has a name, use that as part of the new ID
+      const name = element.name || ''
+      const newId = generateID(name)
+
+      element.id = newId
+
+      const relatedLabel = wrapper.querySelector(`[for="${oldId}"]`)
+      if (relatedLabel) {
+        relatedLabel.setAttribute('for', newId)
+      }
+    })
+
+  return wrapper
+}
+
+function closest (element, selector) {
+  if (!element) {
+    return
+  }
+
+  if (!element.matches) {
+    element.prototype.matches = element.prototype.msMatchesSelector || element.prototype.webkitMatchesSelector
+  }
+
+  let parent
+
+  // traverse parents
+  while (element) {
+    parent = element.parentElement
+    if (parent && parent.matches(selector)) {
+      return parent
+    }
+    element = parent
+  }
+
+  return null
+}
+
 module.exports = {
   addClass,
   removeClass,
-  hasClass
+  hasClass,
+  toggleClass,
+  generateID,
+  isNodeList,
+  findDoc,
+  insertAfter,
+  hide,
+  show,
+  createElementFromMarkup,
+  removeElement,
+  regenIds,
+  resetFieldValues,
+  closest,
 }

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -13,7 +13,10 @@ require('../lib/exit_warn')
 const HighlightControl = require('../components/highlightcontrol')
 const ConditionalSubfields = require('../components/conditional_subfields')
 const PrintSection = require('../components/print_section')
+const AddAnother = require('../components/add_another')
+
 
 HighlightControl.init()
 ConditionalSubfields.init()
 PrintSection.init()
+AddAnother.init()

--- a/app/models/research_session.rb
+++ b/app/models/research_session.rb
@@ -1,10 +1,9 @@
 class ResearchSession < ApplicationRecord
-  validates :researcher_name, presence: true,
-            if: -> (session) { session.reached_step?(:researcher) }
-  validates :researcher_email, presence: true,
-            if: -> (session) { session.reached_step?(:researcher) }
-  validates :researcher_email, format: /@/,
-    if: -> (session) { session.researcher_email.present? && session.reached_step?(:researcher) }
+  has_many :researchers
+  accepts_nested_attributes_for :researchers
+
+  validates :researchers, presence: true,
+    if: -> (session) { session.reached_step?(:researcher) }
 
   validates :topic, presence: true,
     if: -> (session) { session.reached_step?(:topic) }

--- a/app/models/research_session/steps.rb
+++ b/app/models/research_session/steps.rb
@@ -5,8 +5,8 @@ class ResearchSession
     include Singleton
 
     PARAMS = ActiveSupport::OrderedHash[{
-      researcher:    [:researcher_name, :researcher_phone, :researcher_email,
-                      :researcher_other, :researcher_other_name, :researcher_other_name],
+      researcher:    [researchers_attributes:
+        [:researcher_name, :researcher_phone, :researcher_email]],
       topic:         [:topic],
       purpose:       [:purpose],
       methodologies: [:other_methodology, methodologies: []],
@@ -40,7 +40,15 @@ class ResearchSession
               params_to_steps[param] = step
             when Hash
               param.keys.each do |array_param|
-                params_to_steps[array_param] = step
+                nested_params = param[array_param]
+                if nested_params.any?
+                  # Only checks one level of nesting. If you find yourself passing
+                  # a doubly-nested thing hash or deeper here this will need
+                  # revisiting
+                  nested_params.each { |nested_param| params_to_steps[nested_param] = step }
+                else
+                  params_to_steps[array_param] = step
+                end
               end
             end
           end

--- a/app/models/researcher.rb
+++ b/app/models/researcher.rb
@@ -1,0 +1,6 @@
+class Researcher < ApplicationRecord
+  belongs_to :research_session
+
+  validates :researcher_name, presence: true
+  validates :researcher_email, format: /@/
+end

--- a/app/presenters/research_session_presenter.rb
+++ b/app/presenters/research_session_presenter.rb
@@ -8,6 +8,12 @@ class ResearchSessionPresenter < Struct.new(:research_session)
   delegate :unable_to_consent?, :able_to_consent?, :reached_step?,
            to: :research_session
 
+  [:researcher_name, :researcher_email, :researcher_phone].each do |attr|
+    define_method(attr) do
+      research_session.researchers.first.send attr
+    end
+  end
+
   def methodology_list
     paras = research_session.methodologies.map do |methodology|
       translation = if methodology.to_s == 'other'

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -52,11 +52,6 @@
     <h3 class="subtitle-small" id="who">Who is doing the research?</h3>
     <p>
       <%= edit_link_for(:researcher_name) %> is the researcher who will be leading the session.
-      <% if @research_session.researcher_other_name.present? %>
-        <%= edit_link_for(:researcher_name) %>ʼs colleague,
-        <%= edit_link_for(:researcher_other_name) %>,
-        may join <%= edit_link_for(:researcher_name) %> sometimes to help.
-      <% end %>
     </p>
   </section>
   <section>

--- a/app/views/research_sessions/researcher.html.erb
+++ b/app/views/research_sessions/researcher.html.erb
@@ -2,34 +2,23 @@
 <div class="main-content">
   <%= render 'error_summary' %>
   <h1 class="subtitle-large">Researcher</h1>
+
+  <p>
+    Who are the researchers working on this sesion? Please note:
+    participants will be informed that they can get further information from these people,
+    and their contact details will be included on the information sheet.
+  </p>
+
   <%= barnardos_form_with model: @research_session, url: wizard_path do |form| %>
-
-    <fieldset class="fieldset" name="first-researcher">
-      <legend class="fieldset__legend">Who will the participants meet as part of the session?</legend>
-      <p>
-        Who is the person who is leading the research or participation session? Please note:
-        participants will be informed that they can get further information from this person,
-        and their contact details will be included on the information sheet.
-      </p>
-
-      <%= form.labelled_text_field :researcher_name %>
-      <%= form.labelled_text_field :researcher_phone %>
-      <%= form.labelled_text_field :researcher_email %>
-    </fieldset>
-
-    <fieldset class="fieldset" name="second-researcher">
-      <legend class="visually-hidden">Additional researcher</legend>
-
-      <%= form.radio_group_vertical \
-          :researcher_other,
-          { false => 'No', true => 'Yes' },
-          legend: 'Will the participants meet any other researchers / observers?' %>
-
-      <div class="js-ConditionalSubfield" data-controlled-by="research_session[researcher_other]" data-control-value="true">
-        <%= form.labelled_text_field :researcher_other_name %>
-      </div>
-    </fieldset>
+    <%= form.fields_for :researchers do |research_fields| %>
+      <fieldset class="fieldset">
+        <%= research_fields.labelled_text_field :researcher_name %>
+        <%= research_fields.labelled_text_field :researcher_phone %>
+        <%= research_fields.labelled_text_field :researcher_email %>
+      </fieldset>
+    <% end %>
 
     <%= render 'button_bar' %>
+
   <% end %>
 </div>

--- a/app/views/research_sessions/researcher.html.erb
+++ b/app/views/research_sessions/researcher.html.erb
@@ -1,7 +1,7 @@
 <%= render "research_sessions/progress" %>
 <div class="main-content">
   <%= render 'error_summary' %>
-  <h1 class="subtitle-large">Researcher</h1>
+  <h1 class="subtitle-large">Researchers</h1>
 
   <p>
     Who are the researchers working on this sesion? Please note:
@@ -10,15 +10,20 @@
   </p>
 
   <%= barnardos_form_with model: @research_session, url: wizard_path do |form| %>
-    <%= form.fields_for :researchers do |research_fields| %>
-      <fieldset class="fieldset">
-        <%= research_fields.labelled_text_field :researcher_name %>
-        <%= research_fields.labelled_text_field :researcher_phone %>
-        <%= research_fields.labelled_text_field :researcher_email %>
-      </fieldset>
-    <% end %>
+    <div class="js-AddAnother fieldset-list"
+      data-item-selector=".js-researcher"
+      data-item-name="researcher"
+    >
+      <%= form.fields_for :researchers do |research_fields| %>
+        <fieldset class="fieldset js-researcher">
+          <legend class="subtitle-medium">Researcher</legend>
+          <%= research_fields.labelled_text_field :researcher_name %>
+          <%= research_fields.labelled_text_field :researcher_phone %>
+          <%= research_fields.labelled_text_field :researcher_email %>
+        </fieldset>
+      <% end %>
+    </div>
 
     <%= render 'button_bar' %>
-
   <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,10 +34,6 @@ en:
     shared_duration: "How long will this information be held for?"
     shared_use: "How will the data be used?"
     shared_with: "Who will the data be shared with?"
-    researcher_name: 'Full name'
-    researcher_other_name: 'Full name'
-    researcher_phone: 'Telephone number (optional)'
-    researcher_email: 'Email'
     topic: 'What is the research or participation session about?'
     purpose: 'Why are you doing this research or participation session?'
     methodologies: 'How will you be gathering information?'
@@ -53,7 +49,18 @@ en:
     food_provided: "Will you provide food or refreshments at the session? (optional)"
     incentive: "Will an incentive be provided?"
     payment_type: "What form will the incentive take?"
-
+    researchers:
+      researcher_name: 'Full name'
+      researcher_phone: 'Telephone number (optional)'
+      researcher_email: 'Email'
+      one:
+        researcher_name: 'Full name'
+        researcher_phone: 'Telephone number (optional)'
+        researcher_email: 'Email'
+      other:
+        researcher_name: 'Full name'
+        researcher_phone: 'Telephone number (optional)'
+        researcher_email: 'Email'
   activerecord:
     attributes:
       research_session:

--- a/db/migrate/20170927200122_researchers.rb
+++ b/db/migrate/20170927200122_researchers.rb
@@ -1,0 +1,16 @@
+class Researchers < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :research_sessions, :researcher_name, :string
+    remove_column :research_sessions, :researcher_phone, :string
+    remove_column :research_sessions, :researcher_email, :string
+    remove_column :research_sessions, :researcher_other, :boolean
+    remove_column :research_sessions, :researcher_other_name, :string
+
+    create_table :researchers do |t|
+      t.string :researcher_name
+      t.string :researcher_phone
+      t.string :researcher_email
+      t.belongs_to :research_session, index: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170904155000) do
+ActiveRecord::Schema.define(version: 20170927200122) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,10 +20,6 @@ ActiveRecord::Schema.define(version: 20170904155000) do
     t.string "age", default: "over18"
     t.string "methodologies", array: true
     t.string "recording_methods", array: true
-    t.string "researcher_name"
-    t.string "researcher_phone"
-    t.string "researcher_email"
-    t.string "researcher_other_name"
     t.boolean "incentive", default: false
     t.string "payment_type"
     t.decimal "incentive_value"
@@ -31,7 +27,6 @@ ActiveRecord::Schema.define(version: 20170904155000) do
     t.datetime "updated_at", null: false
     t.string "other_methodology"
     t.string "other_recording_method"
-    t.boolean "researcher_other"
     t.text "topic"
     t.text "purpose"
     t.string "shared_with"
@@ -46,6 +41,14 @@ ActiveRecord::Schema.define(version: 20170904155000) do
     t.boolean "receipts_required", default: true
     t.text "food_provided"
     t.index ["status"], name: "index_research_sessions_on_status"
+  end
+
+  create_table "researchers", force: :cascade do |t|
+    t.string "researcher_name"
+    t.string "researcher_phone"
+    t.string "researcher_email"
+    t.bigint "research_session_id"
+    t.index ["research_session_id"], name: "index_researchers_on_research_session_id"
   end
 
 end

--- a/features/step_definitions/question_steps.rb
+++ b/features/step_definitions/question_steps.rb
@@ -4,15 +4,9 @@ When(/^I provide full session details for a child-age cohort$/) do
 
   click_button 'Create new form'
 
-  within '[name="first-researcher"]' do
-    fill_in 'Full name', with: 'Rachel Researcher'
-    fill_in 'Telephone number', with: '012345678'
-    fill_in 'Email', with: 'rachel@researcher.com'
-  end
-
-  within '[name="second-researcher"]' do
-    fill_in 'Full name', with: 'Steve Secondresearcher'
-  end
+  fill_in 'Full name', with: 'Rachel Researcher'
+  fill_in 'Telephone number', with: '012345678'
+  fill_in 'Email', with: 'rachel@researcher.com'
 
   Percy::Capybara.snapshot(page, name: :researcher)
   click_button 'Continue'

--- a/spec/factories/research_session.rb
+++ b/spec/factories/research_session.rb
@@ -2,8 +2,8 @@ FactoryGirl.define do
   factory :research_session do
     trait :step_researcher do
       status :researcher
-      researcher_name 'Rachel Researcher'
-      researcher_email 'r.researcher@barnardos.org.uk'
+
+      researchers { build_list :researcher, 1 }
     end
 
     trait :step_topic do

--- a/spec/factories/researcher.rb
+++ b/spec/factories/researcher.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :researcher do
+    researcher_name 'Rachel Researcher'
+    researcher_email 'r.researcher@barnardos.org.uk'
+
+    research_session
+  end
+end

--- a/spec/helpers/research_sessions_helper_spec.rb
+++ b/spec/helpers/research_sessions_helper_spec.rb
@@ -24,11 +24,11 @@ RSpec.describe ResearchSessionsHelper, :type => :helper do
     end
 
     context 'the attr is one we know about' do
-      let(:attr) { :researcher_name }
+      let(:attr) { :topic }
 
-      context 'a researcher attribute' do
-        it 'links to the researcher step' do
-          expect(rendered).to have_tag('a', href: '/questions/researcher', text: /Some attr value/)
+      context 'a topic attribute' do
+        it 'links to the topic step' do
+          expect(rendered).to have_tag('a', href: '/questions/topic', text: /Some attr value/)
         end
       end
 

--- a/spec/presenters/research_session_presenter_spec.rb
+++ b/spec/presenters/research_session_presenter_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 RSpec.describe ResearchSessionPresenter do
   include RSpecHtmlMatchers
 
-  let(:research_session) { spy('ResearchSession') }
+  let(:research_session) { spy('ResearchSession', researchers: [researcher]) }
+  let(:researcher)       { spy('Researcher') }
 
   subject(:presenter) { ResearchSessionPresenter.new(research_session) }
 
@@ -11,11 +12,17 @@ RSpec.describe ResearchSessionPresenter do
     expect(presenter.research_session).to eql(research_session)
   end
 
-  [:age, :topic, :purpose, :researcher_name, :researcher_other_name,
-   :researcher_email, :researcher_phone].each do |method|
+  [:age, :topic, :purpose].each do |method|
     it "delegates #{method} to the research_session" do
       presenter.send method
       expect(research_session).to have_received(method)
+    end
+  end
+
+  [:researcher_name, :researcher_email, :researcher_phone].each do |method|
+    it "delegates #{method} to the first researcher" do
+      presenter.send method
+      expect(researcher).to have_received(method)
     end
   end
 


### PR DESCRIPTION
# Add Another Researcher

https://consent-form-builder-st-pr-116.herokuapp.com/research-sessions/1/questions/researcher

## Requirements
The premise is simple.  

> As a user creating a research session
> And I am on the 'Researcher' screen
> Then I can define one or more researchers associated with this research session

## Solution
Instead of having the researcher and researcher_ other in the research session table, we create a new table 'researchers' and create a one to many relationship.

When the user goes to the researcher form it will show the single researcher fields it did previously, but now has an 'add another researcher' button to allow more than one to be created.

When the user reaches the preview page it will loop through the researchers.

The add another feature is provided by a javascript component that clones the page element and resets its values. The form data is handled using nested Rails forms.

![add-another](https://user-images.githubusercontent.com/56056/31019357-5bf7f8a8-a527-11e7-940d-5dc51d8183b7.PNG)

## Tasks
- [x] Update model to create session -> researchers
- [x] Update researcher screen to show a single researcher
- [x] Add a new 'AddAnother' js control to allow a fragment of the page to be tagged and an add button created. When the add button is pressed the fragment is cloned and values reset.
- [x] Add some tests for the new control
- [ ] Update validation to require at least one researcher
- [ ] Check form validation
- [ ] Check form data population
- [ ] Update the preview page to support multiple researchers and drop researcher_other
- [ ] Update RSpec tests (part done)
- [ ] Update cucumber tests
- [ ] Add a field to researcher to ask for researcher role