### PR TITLE
Changelog and rudimentary serving from /changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# 0.2.0 / Unreleased
+
+* [USABILITY] - [Major preview copy changes – bring through data sharing, incentives etc](https://trello.com/c/lxrTEvdo/157-5-validate-that-all-relevant-content-from-the-form-is-reflected-in-the-preview-copy)
+* [USABILITY] - [Dynamic Preview Copy - Can or Can't give consent](https://trello.com/c/uexOizmX/146-dynamic-preview-copy-can-or-cant-give-consent)
+* [BUGFIX] - [Make the date and time of the session optional](https://trello.com/c/MfcP4OQX/149-3-in-reality-the-date-and-time-of-the-session-is-not-optional)
+* [FEATURE] - [Ability to print consent form and info sheets separately](https://trello.com/c/EhJjHEjS/158-ability-to-print-consent-form-and-info-sheets-separately)
+* [BUGFIX] - [Tidy up the inline error styles](https://trello.com/c/qmwS3Q2b/164-tidy-up-the-inline-error-styles)
+* [BUGFIX] - [Tabbing through checkboxes now works](https://trello.com/c/AtwZN5N8/136-tabbing-through-checkboxes-isnt-working)
+* [USABILITY] - [Remove Cancel button](https://trello.com/c/XWoysuWu/107-1-remove-cancel-button)
+* [BUGFIX] - [Header section causing horizontal scroll](https://trello.com/c/IukVaf3c/100-2-header-section-causing-horizontal-scroll)
+* [BUGFIX] - [When a textarea has an error, form helper outputs a label within a label](https://trello.com/c/XDkR3yhr/165-bug-when-a-textarea-has-an-error-form-helper-outputs-a-label-within-a-label)
+* [BUGFIX] - [Preview page links should return to the appropriate page of the Consent Form Builder for editing](https://trello.com/c/p6HAGJRa/176-bug-preview-page-links-should-return-to-the-appropriate-page-of-the-consent-form-builder-for-editing)
+* [BUGFIX] - Researcher screen: font size issue
+* [BUGFIX] - [Fix hard crash when no checkboxes are selected](https://trello.com/c/Yz48ihXf/177-3-bug-if-you-dont-select-from-a-list-of-checkboxes-when-thats-the-only-input-you-get-this-error)
+* [USABILITY] - [Researcher page: Last question should not read "/participant" it should say /secondary researcher or /observer](https://trello.com/c/vVxZhTh1/168-1-researcher-page-last-question-should-not-read-participant-it-should-say-secondary-researcher-or-observer)
+
+# 0.1.0 / 2017-09-19
+
+* Initial release for which there is a log. For reference, things which the release includes are below
+* Returnable URLs – individual question steps within a research session are addressable
+* Errors are on fields
+* Nine-step process
+* Able/unable to give consent (as opposed to "age")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [BUGFIX] - Researcher screen: font size issue
 * [BUGFIX] - [Fix hard crash when no checkboxes are selected](https://trello.com/c/Yz48ihXf/177-3-bug-if-you-dont-select-from-a-list-of-checkboxes-when-thats-the-only-input-you-get-this-error)
 * [USABILITY] - [Researcher page: Last question should not read "/participant" it should say /secondary researcher or /observer](https://trello.com/c/vVxZhTh1/168-1-researcher-page-last-question-should-not-read-participant-it-should-say-secondary-researcher-or-observer)
+* [CHORE] - [This changelog](https://trello.com/c/8HFvUI0z/109-spike-ensure-that-each-release-has-an-appropriate-version-and-codename-based-on-semver-and-ntwicm-releases-4h#comment-59d3aa4e68fe1471489a1090)
 
 # 0.1.0 / 2017-09-19
 

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'jbuilder', '~> 2.5'
 gem 'webpacker', '~> 2.0'
 gem 'wicked', '~> 1.3.2'
 gem 'percy-capybara'
+gem 'vandamme', '~> 0.0.12'
 
 group :development, :test do
   gem 'rspec-rails', '~> 3.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,8 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
+    commonmarker (0.14.15)
+      ruby-enum (~> 0.5)
     concurrent-ruby (1.0.5)
     cucumber (2.4.0)
       builder (>= 2.1.2)
@@ -89,6 +91,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
     gherkin (4.1.3)
+    github-markup (1.6.1)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     httpclient (2.8.3)
@@ -198,6 +201,8 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-enum (0.7.1)
+      i18n
     ruby-progressbar (1.8.1)
     ruby_dep (1.5.0)
     sass (3.4.24)
@@ -227,6 +232,9 @@ GEM
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.3.0)
+    vandamme (0.0.12)
+      commonmarker (~> 0.14.14)
+      github-markup (~> 1.3)
     web-console (3.5.1)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -268,6 +276,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
   uglifier (>= 1.3.0)
+  vandamme (~> 0.0.12)
   web-console (>= 3.3.0)
   webpacker (~> 2.0)
   wicked (~> 1.3.2)

--- a/app/controllers/changelogs_controller.rb
+++ b/app/controllers/changelogs_controller.rb
@@ -1,0 +1,14 @@
+require 'vandamme'
+
+class ChangelogsController < ApplicationController
+  def show
+    @releases = parser.parse
+  end
+
+private
+
+  def parser
+    content = File.read(File.join(Rails.root, 'CHANGELOG.md'))
+    @_parser ||= Vandamme::Parser.new(changelog: content, format: :md)
+  end
+end

--- a/app/views/changelogs/show.html.erb
+++ b/app/views/changelogs/show.html.erb
@@ -1,0 +1,20 @@
+<style>
+  .changelog ul {
+    list-style-type: disc;
+    margin: 0 32px;
+  }
+
+  .changelog ul > * {
+    line-height: 24px;
+  }
+
+</style>
+
+<h1 class="subtitle-large">Changelog</h1>
+
+<div class="changelog">
+<% @_parser.to_html.each do |release, body| %>
+  <h1 class="subtitle-medium">v<%= release %></h1>
+  <%= body.html_safe %>
+<% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,5 @@ Rails.application.routes.draw do
   end
 
   get '/gallery/', to: 'gallery#index'
+  resource :changelog
 end


### PR DESCRIPTION
Add a CHANGELOG.md and serve if from `/changelog`

Comes with no tests at present, given that this was for a little spike.
Add a CHANGELOG.md using the suggested changelog standard for the
vandamme gem (used by Gemnasium). It's not particularly mature, but
it's less important that we agree on its content; more that we agree
on something that communicates our changes.

<img width="642" alt="screen shot 2017-10-04 at 12 03 54" src="https://user-images.githubusercontent.com/194511/31172612-2d96b9bc-a8fc-11e7-81a3-0d1365b58e9d.png">
