### PR TITLE
add styles for select fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.3.0 / Unreleased
 
 * [USABILITY] - [Consistency: change order of No then Yes](https://trello.com/c/IjZuVOkS/182-consistency-change-order-of-no-then-yes)
+* [FEATURE] - [Style select form fields](https://trello.com/c/Oi7CBb0t/180-style-select-form-fields)
 
 # 0.2.0 / 2017-10-04
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,6 +17,7 @@
 @import "barnardos/split-link";
 @import "barnardos/textarea";
 @import "barnardos/textfield";
+@import "barnardos/selectfield";
 @import "barnardos/type";
 
 @import "app/session_preview";

--- a/app/assets/stylesheets/barnardos/_selectfield.scss
+++ b/app/assets/stylesheets/barnardos/_selectfield.scss
@@ -1,0 +1,32 @@
+.selectfield {
+  position: relative;
+  display: inline-block;
+
+  &::before {
+    content: "";
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 6px 5px 0 5px;
+    border-color: $black transparent transparent transparent;
+    position: absolute;
+    right: $gutter;
+    top: 50%;
+    margin-top: -3px;
+  }
+
+  select {
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+
+    padding: $gutter / 2;
+    padding-right: $gutter + 10px + $gutter;
+    font-size: $base-font-size;
+    margin: 0;
+    color: $black;
+    border: solid 1px $border;
+    border-radius: $border-radius;
+    background-color: transparent;
+  }
+}

--- a/app/views/gallery/index.html.erb
+++ b/app/views/gallery/index.html.erb
@@ -19,6 +19,19 @@
   grid while allowing more flexibility in setting type than multiples of 8.
 </p>
 
+<form action="#">
+  <label for="area-to-print" class="selectfield">
+    <select name="area-to-print" id="area-to-print" class="print-section__select js-area-to-print">
+      <option value="" disabled selected>Choose an option</option>
+      <option value="">Option 1</option>
+      <option value="">Option 2</option>
+      <option value="">Option 3</option>
+      <option value="">Option 4</option>
+      <option value="">Option 5</option>
+    </select>
+  </label>
+</form>
+
 <div class="progress">
   <ol class="progress-bar ">
 

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -1,11 +1,13 @@
 <%= render "research_sessions/progress", preview: true %>
 
 <form class="print-section screen-only js-print-section" action="#">
-  <select name="area-to-print" id="area-to-print" class="print-section__select js-area-to-print">
-    <option value="#consent-form,#info-sheets">Consent Form and Info Sheet</option>
-    <option value="#consent-form">Consent Form</option>
-    <option value="#info-sheets">Info Sheet</option>
-  </select>
+  <label for="area-to-print" class="selectfield">
+      <select name="area-to-print" id="area-to-print" class="print-section__select js-area-to-print">
+        <option value="#consent-form,#info-sheets">Consent Form and Info Sheet</option>
+        <option value="#consent-form">Consent Form</option>
+        <option value="#info-sheets">Info Sheet</option>
+      </select>
+  </label>
   <button type="submit" class="print-section__submit button">Print</button>
 </form>
 


### PR DESCRIPTION
Created styles for the select fields from the forms designs. They
haven't been applied to the date/time select field due to its'
dependency with the rails form builder helper.

![image](https://user-images.githubusercontent.com/893208/31217968-a9a126c8-a9b0-11e7-84c8-082d4697f01e.png)
