### PR TITLE
Remove the concept of age

### DIFF
--- a/app/controllers/research_sessions_controller.rb
+++ b/app/controllers/research_sessions_controller.rb
@@ -27,11 +27,12 @@ class ResearchSessionsController < ApplicationController
     @research_session = current_research_session
 
     # Allow the user to pass a parameter to switch between over 18 and under 18 mode
-    if params.key?('age')
-      @research_session.assign_attributes(params.permit(:age))
-    end
+    able_to_consent = params['able-to-consent'] == 'yes' ? true : false
 
-    @research_session = ResearchSessionPresenter.new(@research_session)
+    @research_session = ResearchSessionPresenter.new(
+      @research_session,
+      able_to_consent: able_to_consent
+    )
   end
 
   def update

--- a/app/models/research_session.rb
+++ b/app/models/research_session.rb
@@ -44,14 +44,6 @@ class ResearchSession < ApplicationRecord
   validates :incentive_value, presence: true,
             if: -> (session) { session.incentive && session.reached_step?(:incentive) }
 
-  def able_to_consent?
-    age == 'over18'
-  end
-
-  def unable_to_consent?
-    !able_to_consent?
-  end
-
   def reached_step?(step)
     Steps.instance.reached_step?(self, step)
   end

--- a/app/presenters/research_session_presenter.rb
+++ b/app/presenters/research_session_presenter.rb
@@ -1,19 +1,33 @@
-class ResearchSessionPresenter < Struct.new(:research_session)
+class ResearchSessionPresenter
   include ActionView::Helpers::NumberHelper
+
+  attr_accessor :research_session
+  def initialize(research_session, able_to_consent: false)
+    self.research_session = research_session
+    @able_to_consent = able_to_consent
+  end
 
   ResearchSession.attribute_names.each do |attribute|
     delegate attribute, to: :research_session
   end
 
-  delegate :unable_to_consent?, :able_to_consent?, :reached_step?,
-           to: :research_session
+  delegate :reached_step?, to: :research_session
+
+  def able_to_consent?
+    @able_to_consent
+  end
+
+  def unable_to_consent?
+    !@able_to_consent
+  end
 
   def methodology_list
+    consent_translation_key = @able_to_consent ? 'able_to_consent' : 'unable_to_consent'
     paras = research_session.methodologies.map do |methodology|
       translation = if methodology.to_s == 'other'
                       other_methodology
                     else
-                      I18n.t("report.#{age}.#{methodology}")
+                      I18n.t("report.#{consent_translation_key}.#{methodology}")
                     end
       "<p class='highlight'>#{translation}</p>"
     end

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -13,10 +13,10 @@
 
 <section class="split-link screen-only">
   <div class="<%='active' if @research_session.able_to_consent? %>">
-    <a id="over18-link" href="?age=over18">Respondents who can give consent themselves</a>
+    <a href="?able-to-consent=yes">Respondents who can give consent themselves</a>
   </div>
   <div class="<%='active' if @research_session.unable_to_consent? %>">
-    <a id="under18-link" href="?age=under18">Respondents who can't give consent</a>
+    <a href="?able-to-consent=no">Respondents who can't give consent</a>
   </div>
 </section>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,7 +77,7 @@ en:
         format: '%u%n'
 
   report:
-    over18:
+    able_to_consent:
       interview: 'You will be interviewed and asked your views regarding the project being researched.'
       usability: 'You will be asked to do several short tasks using a website while our researcher watches, listens and takes notes.
         Youʼll need to think out loud as you work so that the researcher can understand what youʼre doing and why.
@@ -89,7 +89,7 @@ en:
         this time you will discuss idea and needs for a service or product and help formalise a solution and next steps.'
       observation: 'You will be observed carrying out tasks within your normal role'
 
-    under18:
+    unable_to_consent:
       interview: 'Your child will be interviewed and asked your views regarding the project being researched.'
       usability: "Your child will be asked to do several short tasks using a website while our researcher watches, listens and takes notes.
         Your child will need to think out loud as they work so that the researcher can understand what they're doing and why.

--- a/db/migrate/20171005095604_replace_age_with_consent.rb
+++ b/db/migrate/20171005095604_replace_age_with_consent.rb
@@ -1,0 +1,5 @@
+class ReplaceAgeWithConsent < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :research_sessions, :age, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170904155000) do
+ActiveRecord::Schema.define(version: 20171005095604) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "research_sessions", force: :cascade do |t|
     t.string "status", default: "new"
-    t.string "age", default: "over18"
     t.string "methodologies", array: true
     t.string "recording_methods", array: true
     t.string "researcher_name"

--- a/features/support/preview_checker.rb
+++ b/features/support/preview_checker.rb
@@ -26,7 +26,7 @@ module PreviewChecker
       methodology = Methodologies::NAME_VALUES.key(methodology_display_name)
       expect(page.body).to have_tag(
         'a.editable',
-        text: Regexp.new(I18n.t("report.under18.#{methodology}"))
+        text: Regexp.new(I18n.t("report.unable_to_consent.#{methodology}"))
       )
     end
   end

--- a/spec/models/research_session_spec.rb
+++ b/spec/models/research_session_spec.rb
@@ -8,20 +8,6 @@ RSpec.describe ResearchSession, type: :model do
       expect(session.status).to eql('new')
     end
 
-    describe '#un/able_to_consent?' do
-      before { session.age = age }
-      context 'is too young' do
-        let(:age) { 'under18' }
-        it { is_expected.not_to be_able_to_consent }
-        it { is_expected.to be_unable_to_consent }
-      end
-      context 'is old enough' do
-        let(:age) { 'over18' }
-        it { is_expected.to be_able_to_consent }
-        it { is_expected.not_to be_unable_to_consent }
-      end
-    end
-
     describe '#reached_step?' do
       it 'passes through to Steps' do
         steps_spy = spy('Steps')

--- a/spec/presenters/research_session_presenter_spec.rb
+++ b/spec/presenters/research_session_presenter_spec.rb
@@ -4,14 +4,20 @@ RSpec.describe ResearchSessionPresenter do
   include RSpecHtmlMatchers
 
   let(:research_session) { spy('ResearchSession') }
+  let(:able_to_consent) { false }
 
-  subject(:presenter) { ResearchSessionPresenter.new(research_session) }
+  subject(:presenter) do
+    ResearchSessionPresenter.new(
+      research_session,
+      able_to_consent: able_to_consent
+    )
+  end
 
   it 'holds on to the research session' do
     expect(presenter.research_session).to eql(research_session)
   end
 
-  [:age, :topic, :purpose, :researcher_name, :researcher_other_name,
+  [:topic, :purpose, :researcher_name, :researcher_other_name,
    :researcher_email, :researcher_phone].each do |method|
     it "delegates #{method} to the research_session" do
       presenter.send method
@@ -19,17 +25,29 @@ RSpec.describe ResearchSessionPresenter do
     end
   end
 
+  describe '#un/able_to_consent?' do
+    context 'participant is unable to consent' do
+      let(:able_to_consent) { false }
+      it { is_expected.not_to be_able_to_consent }
+      it { is_expected.to be_unable_to_consent }
+    end
+    context 'participant is able to consent' do
+      let(:able_to_consent) { true }
+      it { is_expected.to be_able_to_consent }
+      it { is_expected.not_to be_unable_to_consent }
+    end
+  end
+
   describe '#methodology_list' do
     let(:methodologies) { [:interview, :usability] }
     before do
-      allow(research_session).to receive(:age).and_return(age)
       allow(research_session).to receive(:methodologies).and_return(methodologies)
     end
 
     subject(:list) { presenter.methodology_list }
 
-    context 'the research session is targeted at children' do
-      let(:age) { 'under18' }
+    context 'participants are unable to consent' do
+      let(:able_to_consent) { false }
       it 'has as many paragraphs as there are methodologies' do
         expect(list).to have_tag('p', count: 2)
       end
@@ -42,8 +60,8 @@ RSpec.describe ResearchSessionPresenter do
       end
     end
 
-    context 'the research session is targeted at adults' do
-      let(:age) { 'over18' }
+    context 'participants are able to consent' do
+      let(:able_to_consent) { true }
       it 'has as many paragraphs as there are methodologies' do
         expect(list).to have_tag('p', count: 2)
       end

--- a/spec/views/research_session/preview.html.erb_spec.rb
+++ b/spec/views/research_session/preview.html.erb_spec.rb
@@ -1,12 +1,22 @@
 require 'rails_helper'
 
 describe 'research_sessions/preview' do
+  let(:extra_attrs)     { {} }
+  let(:able_to_consent) { false }
+
   let(:research_session) do
     build_stubbed :research_session, :previewable, extra_attrs
   end
 
+  let(:presenter) do
+    ResearchSessionPresenter.new(
+      research_session,
+      able_to_consent: able_to_consent
+    )
+  end
+
   before do
-    assign(:research_session, ResearchSessionPresenter.new(research_session))
+    assign(:research_session, presenter)
     stub_template 'research_sessions/_progress' => '<%= NOT RENDERED %>'
     render
   end
@@ -43,7 +53,7 @@ describe 'research_sessions/preview' do
   end
 
   context 'the participant is able to give consent' do
-    let(:extra_attrs) { { age: 'over18' } }
+    let(:able_to_consent) { true }
 
     it 'phrases blocks using "you"' do
       expect(rendered).to have_content(
@@ -59,7 +69,7 @@ describe 'research_sessions/preview' do
   end
 
   context 'the participant is not able to give consent' do
-    let(:extra_attrs) { { age: 'under18' } }
+    let(:able_to_consent) { false }
 
     it 'phrases blocks using "your child"' do
       expect(rendered).to have_content(


### PR DESCRIPTION
# [Remove the concept of 'age'](https://trello.com/c/fX16cbOX/160-5-tech-debt-remove-the-concept-of-age)

Since we only talk about the ability to give consent, storing age is
misleading. Instead, use a query string parameter `able_to_consent` to
determine the preview content at the end of the wizard.

Since this is now a view concern only, move
`ResearchSession#able_to_consent?` and `ResearchSession#unable_to_consent?`
to `ResearchSessionPresenter`. Pass the ability to consent or otherwise
directly from the query string to the presenter in the controller.