### PR TITLE
Ensure yes/no radios are consistent

### DIFF
--- a/app/views/research_sessions/researcher.html.erb
+++ b/app/views/research_sessions/researcher.html.erb
@@ -22,7 +22,7 @@
 
       <%= form.radio_group_vertical \
           :researcher_other,
-          { false => 'No', true => 'Yes' },
+          { true => 'Yes', false => 'No' },
           legend: 'Will the participants meet any other researchers / observers?' %>
 
       <div class="js-ConditionalSubfield" data-controlled-by="research_session[researcher_other]" data-control-value="true">


### PR DESCRIPTION
# [Consistency: change order of No then Yes](https://trello.com/c/IjZuVOkS/182-consistency-change-order-of-no-then-yes)

The yes/no option for `/research` was laid out opposite to the rest of the form causing some confusion for our users.