### PR TITLE
BUG: returning to previous steps in the preview bar disables links to subsequent steps

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -25,3 +25,8 @@ rules:
   quotes:
     - 1
     - style: double
+  shorthand-values:
+    - 1
+    - allowed-shorthands:
+      - 1
+      - 2

--- a/app/controllers/research_sessions_controller.rb
+++ b/app/controllers/research_sessions_controller.rb
@@ -37,7 +37,7 @@ class ResearchSessionsController < ApplicationController
 
   def update
     @research_session = current_research_session
-    @research_session.status = step
+    @research_session.status = step unless @research_session.reached_step?(step)
     @research_session.assign_attributes(question_params)
     render_wizard @research_session
   end

--- a/app/views/research_sessions/_progress.html.erb
+++ b/app/views/research_sessions/_progress.html.erb
@@ -19,7 +19,7 @@
     <% wizard_steps.each do |this_step| %>
       <li
         class="progress__stage
-          <%= 'is-complete' if past_step?(this_step) || preview %>
+          <%= 'is-complete' if @research_session.reached_step?(this_step) %>
           <%= 'is-active' if this_step == step %>">
         <span class="progress__stage-title">
           <% if this_step != step && @research_session.reached_step?(this_step) %>
@@ -35,7 +35,9 @@
       If the user has completed the last step, provide
       a link to the preview section
     %>
-    <li class="progress__stage <%= 'is-active' if preview %>">
+    <li class="progress__stage
+          <%= 'is-complete' if @research_session.reached_step?(wizard_steps.last) %>
+          <%= 'is-active' if preview %>">
       <span class="progress__stage-title">
         <% if !preview && @research_session.reached_step?(wizard_steps.last) %>
           <%= link_to 'Preview', research_session_preview_path(@research_session.id) %>

--- a/app/views/research_sessions/_progress.html.erb
+++ b/app/views/research_sessions/_progress.html.erb
@@ -22,7 +22,7 @@
           <%= 'is-complete' if past_step?(this_step) || preview %>
           <%= 'is-active' if this_step == step %>">
         <span class="progress__stage-title">
-          <% if this_step != step and @research_session and @research_session.reached_step?(this_step) %>
+          <% if this_step != step && @research_session.reached_step?(this_step) %>
             <%= link_to this_step.to_s.humanize, research_session_question_path(@research_session.id, this_step) %>
           <% else %>
             <%= this_step.to_s.humanize %>
@@ -37,7 +37,7 @@
     %>
     <li class="progress__stage <%= 'is-active' if preview %>">
       <span class="progress__stage-title">
-        <% if !preview && @research_session && @research_session.reached_step?(wizard_steps.last) %>
+        <% if !preview && @research_session.reached_step?(wizard_steps.last) %>
           <%= link_to 'Preview', research_session_preview_path(@research_session.id) %>
         <% else %>
           Preview

--- a/spec/controllers/research_sessions_controller_spec.rb
+++ b/spec/controllers/research_sessions_controller_spec.rb
@@ -93,6 +93,21 @@ describe ResearchSessionsController, type: :controller do
       end
     end
 
+    context 'returning to a previous step' do
+      let(:existing_step) { :incentive }
+      let(:params) do
+        {
+          research_session_id: existing_session.id,
+          id: 'methodologies',
+          research_session: { 'methodologies' => ['', 'interview', 'usability'] }
+        }
+      end
+
+      it 'keeps the research session at the step it had reached' do
+        expect(research_session.status).to eql('incentive')
+      end
+    end
+
     context 'the last step' do
       let(:existing_step) { :data }
 


### PR DESCRIPTION
# [BUG: returning to previous steps in the preview bar disables links to subsequent steps](https://trello.com/c/0k7u2liM/199-bug-returning-to-previous-steps-in-the-preview-bar-disables-links-to-subsequent-steps)

When going back from your completed form to edit a step, clicking 'continue' caused the subsequent progress bar steps to become inactive forcing the user to keep clicking continue. This PR fixes this issue as well as:

- Setting styles to always show if a step as been completed, not just previous steps
- Giving the preview step the completed style when viewing previous steps
- Updating the sass lint to not warn us about using 3-value shorthand for box model styling

Before:
![image](https://user-images.githubusercontent.com/893208/31384054-3a7f2aa2-adb5-11e7-8655-c9e94e632730.png)


After:
![image](https://user-images.githubusercontent.com/893208/31384034-29c532c4-adb5-11e7-9867-3641cced102b.png)
