### PR TITLE
Return to preview after edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [BUG] - [Returning to previous steps in the preview bar disables links to subsequent steps](https://trello.com/c/0k7u2liM/199-bug-returning-to-previous-steps-in-the-preview-bar-disables-links-to-subsequent-steps)
 * [USABILITY] - [Consistency: change order of No then Yes](https://trello.com/c/IjZuVOkS/182-consistency-change-order-of-no-then-yes)
 * [FEATURE] - [Style select form fields](https://trello.com/c/Oi7CBb0t/180-style-select-form-fields)
+* [FEATURE] - [When a field is edited from preview, the continue button should return the editor to the preview](https://trello.com/c/6PUIvgXx/196-when-a-field-is-edited-from-preview-the-continue-button-should-return-the-editor-to-the-preview)
 
 # 0.2.0 / 2017-10-04
 

--- a/app/controllers/research_sessions_controller.rb
+++ b/app/controllers/research_sessions_controller.rb
@@ -39,7 +39,11 @@ class ResearchSessionsController < ApplicationController
     @research_session = current_research_session
     @research_session.status = step unless @research_session.reached_step?(step)
     @research_session.assign_attributes(question_params)
-    render_wizard @research_session
+    if returning_to_preview? && @research_session.save
+      redirect_to(research_session_preview_path, research_session_id: @research_session.id)
+    else
+      render_wizard @research_session
+    end
   end
 
   def finish_wizard_path
@@ -47,6 +51,10 @@ class ResearchSessionsController < ApplicationController
   end
 
 private
+  def returning_to_preview?
+    params['edit-preview'] == '1'
+  end
+
   def current_research_session
     ResearchSession.find(params[:research_session_id])
   end

--- a/app/helpers/research_sessions_helper.rb
+++ b/app/helpers/research_sessions_helper.rb
@@ -5,7 +5,10 @@ module ResearchSessionsHelper
     step_for_attr = ResearchSession::Steps.instance.attr_to_step(attr)
 
     link_to value,
-            research_session_question_path(@research_session.id, step_for_attr), class: 'editable'
+            research_session_question_path(
+              @research_session.id, step_for_attr, 'edit-preview' => '1'
+            ),
+            class: 'editable'
   end
 
   def you_or_your_child

--- a/app/views/research_sessions/_button_bar.erb
+++ b/app/views/research_sessions/_button_bar.erb
@@ -1,3 +1,8 @@
 <p class="button-bar">
-  <%= button_tag('Continue', type: :submit, class: 'button') %>
+  <% if params['edit-preview'] == '1' %>
+    <%= hidden_field_tag 'edit-preview', '1' %>
+    <%= button_tag 'Save and return', type: :submit, class: 'button' %>
+  <% else %>
+    <%= button_tag 'Continue', type: :submit, class: 'button' %>
+  <% end %>
 </p>

--- a/features/printed_consent_forms.feature
+++ b/features/printed_consent_forms.feature
@@ -3,8 +3,8 @@ Feature:
   I want to generate combinations of printed consent materials
   So that I can get consent from parents and participants without making mistakes
 
-  Scenario: The session is for a child
-    When I provide full session details for a child-age cohort
+  Scenario: The happy path
+    When I provide full session details for every step
     Then I should see the session review page
     And I should see confirmation that this is a preview
     And I should see the formatted focus of the research along with why

--- a/features/printed_consent_forms.feature
+++ b/features/printed_consent_forms.feature
@@ -14,6 +14,10 @@ Feature:
     And I should see the age-appropriate consent form preview
     And it should have a place for name, signature and date
     And I should see a way to print it
+    When I go back to a previous step
+    Then I should see a way of getting straight back to the preview
+    When I edit that step and continue
+    Then I should see an updated preview
 
   Scenario: I am using a research methodology or recording method that is not in the list
     Given I have arrived at the methodologies step

--- a/features/step_definitions/question_steps.rb
+++ b/features/step_definitions/question_steps.rb
@@ -1,4 +1,4 @@
-When(/^I provide full session details for a child-age cohort$/) do
+When(/^I provide full session details for every step$/) do
   visit '/'
   Percy::Capybara.snapshot(page, name: :home)
 

--- a/features/step_definitions/question_steps.rb
+++ b/features/step_definitions/question_steps.rb
@@ -203,3 +203,17 @@ When(/^I begin a new session at the start$/) do
   visit '/'
   click_button 'Create new form'
 end
+
+When(/^I go back to a previous step$/) do
+  click_link 'Rachel Researcher', match: :first
+end
+
+Then(/^I should see a way of getting straight back to the preview$/) do
+  expect(page).to have_tag('button', text: 'Save and return')
+end
+
+When(/^I edit that step and continue$/) do
+  @new_phone_number = '0772233445566'
+  fill_in 'Telephone number', with: @new_phone_number
+  click_button 'Save and return'
+end

--- a/features/step_definitions/session_review_steps.rb
+++ b/features/step_definitions/session_review_steps.rb
@@ -47,3 +47,7 @@ end
 Then(/^the session should be immediately addressable$/) do
   expect(page.current_path).to match(%r{^/research-sessions/[0-9]*/questions/researcher})
 end
+
+Then(/^I should see an updated preview$/) do
+  expect(page).to have_content(@new_phone_number)
+end

--- a/spec/controllers/research_sessions_controller_spec.rb
+++ b/spec/controllers/research_sessions_controller_spec.rb
@@ -108,6 +108,29 @@ describe ResearchSessionsController, type: :controller do
       end
     end
 
+    context 'editing a previous step and returning directly to preview' do
+      let(:existing_step) { :incentive }
+      let(:new_phone_number) { '01010101010101' }
+      let(:params) do
+        {
+          research_session_id: existing_session.id,
+          id: 'researcher',
+          research_session: { 'researcher_phone' => new_phone_number },
+          'edit-preview' => '1'
+        }
+      end
+
+      it 'updates the research session' do
+        expect(research_session.researcher_phone).to eql(new_phone_number)
+      end
+
+      it 'returns to the preview' do
+        expect(response).to redirect_to(
+          research_session_preview_path(research_session_id: existing_session.id)
+        )
+      end
+    end
+
     context 'the last step' do
       let(:existing_step) { :data }
 

--- a/spec/helpers/research_sessions_helper_spec.rb
+++ b/spec/helpers/research_sessions_helper_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe ResearchSessionsHelper, :type => :helper do
       context 'a researcher attribute' do
         it 'links to the researcher step' do
           expect(rendered).to have_tag(
-            'a', text: /Some attr value/, with: { href: '/research-sessions/1234/questions/researcher?edit-preview=1' }
+            'a', text: /Some attr value/,
+                 with: { href: '/research-sessions/1234/questions/researcher?edit-preview=1' }
           )
         end
       end

--- a/spec/helpers/research_sessions_helper_spec.rb
+++ b/spec/helpers/research_sessions_helper_spec.rb
@@ -28,7 +28,9 @@ RSpec.describe ResearchSessionsHelper, :type => :helper do
 
       context 'a researcher attribute' do
         it 'links to the researcher step' do
-          expect(rendered).to have_tag('a', href: '/questions/researcher', text: /Some attr value/)
+          expect(rendered).to have_tag(
+            'a', text: /Some attr value/, with: { href: '/research-sessions/1234/questions/researcher?edit-preview=1' }
+          )
         end
       end
 


### PR DESCRIPTION
# [When a field is edited from preview, the continue button should return the editor to the preview](https://trello.com/c/6PUIvgXx/196-when-a-field-is-edited-from-preview-the-continue-button-should-return-the-editor-to-the-preview)

As a researcher
I want to go straight back to the preview when I've edited just one thing
So that I don't have to continue through all the wizard steps again

<img width="435" alt="screen shot 2017-10-11 at 10 16 16" src="https://user-images.githubusercontent.com/194511/31432012-48ab93be-ae6d-11e7-90cf-2291facbbcda.png">
