### PR TITLE
Fix IE11 spacing issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [USABILITY] - [Consistency: change order of No then Yes](https://trello.com/c/IjZuVOkS/182-consistency-change-order-of-no-then-yes)
 * [FEATURE] - [Style select form fields](https://trello.com/c/Oi7CBb0t/180-style-select-form-fields)
 * [FEATURE] - [When a field is edited from preview, the continue button should return the editor to the preview](https://trello.com/c/6PUIvgXx/196-when-a-field-is-edited-from-preview-the-continue-button-should-return-the-editor-to-the-preview)
+* [BUG] - [Left gutter is absent on IE11](https://trello.com/c/MHPi5b2K/198-left-gutter-is-absent-on-ie11)
 
 # 0.2.0 / 2017-10-04
 

--- a/app/assets/stylesheets/_reset.scss
+++ b/app/assets/stylesheets/_reset.scss
@@ -26,7 +26,7 @@ time, mark, audio, video {
 }
 /* HTML5 display-role reset for older browsers */
 article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
+footer, header, hgroup, menu, nav, main, section {
 	display: block;
 }
 body {


### PR DESCRIPTION
# [Left gutter is absent on IE11](https://trello.com/c/MHPi5b2K/198-left-gutter-is-absent-on-ie11)

The gutters for the main content were not being displayed on IE11. This
is because IE11 did not apply the style `display: block;` to the `main`
tag.

Before:
![image](https://user-images.githubusercontent.com/893208/31442088-28918a00-ae8d-11e7-9cf9-a0ccb6d06a89.png)

After:
![image](https://user-images.githubusercontent.com/893208/31442108-3843d002-ae8d-11e7-8ad2-b46fee564c2e.png)
