### PR TITLE
Allow additional subfields to show/hide on IE11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [FEATURE] - [Style select form fields](https://trello.com/c/Oi7CBb0t/180-style-select-form-fields)
 * [FEATURE] - [When a field is edited from preview, the continue button should return the editor to the preview](https://trello.com/c/6PUIvgXx/196-when-a-field-is-edited-from-preview-the-continue-button-should-return-the-editor-to-the-preview)
 * [BUG] - [Left gutter is absent on IE11](https://trello.com/c/MHPi5b2K/198-left-gutter-is-absent-on-ie11)
+* [BUG] - ["Other" checkboxes do not show/hide associated fields on IE11](https://trello.com/c/vU78qwtO/197-other-checkboxes-do-not-show-hide-associated-fields-on-ie11)
 
 # 0.2.0 / 2017-10-04
 

--- a/app/javascript/components/conditional_subfields.js
+++ b/app/javascript/components/conditional_subfields.js
@@ -123,7 +123,7 @@ const ConditionalSubfields = {
       const value = subField.getAttribute('data-control-value') + ''
       let isVisible
 
-      isVisible = controlInputValue.includes(value)
+      isVisible = includes(controlInputValue, value)
 
       this._toggleSubField(subField, isVisible)
     })


### PR DESCRIPTION
# ["Other" checkboxes do not show/hide associated fields on IE11](https://trello.com/c/vU78qwtO/197-other-checkboxes-do-not-show-hide-associated-fields-on-ie11)

We need to use the lodash polyfill for `includes` script and not the inbuilt browser
emacscript `array.includes`