### PR TITLE
Ensure selectfield doesn't show 2 arrows on ie11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [FEATURE] - [When a field is edited from preview, the continue button should return the editor to the preview](https://trello.com/c/6PUIvgXx/196-when-a-field-is-edited-from-preview-the-continue-button-should-return-the-editor-to-the-preview)
 * [BUG] - [Left gutter is absent on IE11](https://trello.com/c/MHPi5b2K/198-left-gutter-is-absent-on-ie11)
 * [BUG] - ["Other" checkboxes do not show/hide associated fields on IE11](https://trello.com/c/vU78qwtO/197-other-checkboxes-do-not-show-hide-associated-fields-on-ie11)
+* [BUG] - [IE11 shows two arrows on the print area select field](https://trello.com/c/Y55ixqL5/206-ie11-shows-two-arrows-on-the-print-area-select-field)
 
 # 0.2.0 / 2017-10-04
 

--- a/app/assets/stylesheets/barnardos/_selectfield.scss
+++ b/app/assets/stylesheets/barnardos/_selectfield.scss
@@ -28,5 +28,9 @@
     border: solid 1px $border;
     border-radius: $border-radius;
     background-color: transparent;
+
+    &::-ms-expand {
+      display: none;
+    }
   }
 }


### PR DESCRIPTION
# [IE11 shows two arrows on the print area select field](https://trello.com/c/Y55ixqL5/206-ie11-shows-two-arrows-on-the-print-area-select-field)

IE11 was showing 2 dropdown arrows for the selectfield styles. This
commit adds the pseudo element for IE to remove it's default styles.

Before:
![image](https://user-images.githubusercontent.com/893208/31489628-31fc8598-af39-11e7-84ae-eaba92cd8c72.png)

After:
![image](https://user-images.githubusercontent.com/893208/31489576-00f65c1c-af39-11e7-8590-a1aeef143714.png)
