### PR TITLE
Add location to time and equipment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [BUG] - ["Other" checkboxes do not show/hide associated fields on IE11](https://trello.com/c/vU78qwtO/197-other-checkboxes-do-not-show-hide-associated-fields-on-ie11)
 * [BUG] - [IE11 shows two arrows on the print area select field](https://trello.com/c/Y55ixqL5/206-ie11-shows-two-arrows-on-the-print-area-select-field)
 * [BUG] - [some page furniture obscuring printed preview](https://trello.com/c/1EKgH3tL/188-2-bug-some-page-furniture-obscuring-printed-preview)
+* [FEATURE] - [Add Location (or service information) to the research session screen](https://trello.com/c/yzOexm0b/175-3-add-location-or-service-information-to-the-research-session-screen)
 
 # 0.2.0 / 2017-10-04
 

--- a/app/models/research_session/steps.rb
+++ b/app/models/research_session/steps.rb
@@ -12,7 +12,7 @@ class ResearchSession
       methodologies: [:other_methodology, methodologies: []],
       recording:     [:other_recording_method, recording_methods: []],
       data:          [:shared_with, :shared_duration, :shared_use],
-      time_equipment: [:start_datetime, :duration, :participant_equipment],
+      time_equipment: [:start_datetime, :duration, :location, :participant_equipment],
       expenses:      [:travel_expenses_limit, :food_expenses_limit, :other_expenses_limit,
                       :receipts_required, :food_provided],
       incentive:     [:incentive, :payment_type, :incentive_value]

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -112,6 +112,10 @@
     <p><%= edit_link_for(:shared_use) %></p>
 
     <p>The data will be kept for <%= edit_link_for(:shared_duration) %>.</p>
+
+    <% if @research_session.location.present? %>
+      <p>The session will be held at <%= edit_link_for(:location) %>.</p>
+    <% end %>
   </section>
   <% if @research_session.start_datetime.present? or @research_session.duration.present? %>
     <section>

--- a/app/views/research_sessions/time_equipment.html.erb
+++ b/app/views/research_sessions/time_equipment.html.erb
@@ -14,6 +14,7 @@
     </fieldset>
 
     <%= form.labelled_text_field :duration %>
+    <%= form.labelled_text_field :location %>
 
     <%= form.labelled_text_area :participant_equipment %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,7 @@ en:
     recording_methods: "How will you be recording information?"
     other_recording_method: "What is the other recording method?"
     duration: "How long will the session be? (optional)"
+    location: "Where will the session be? (optional)"
     participant_equipment: "What do participants need to bring? (optional)"
     travel_expenses_limit: "If you allow travel expenses, what is the maximum allowed?"
     food_expenses_limit: "If you allow food expenses, what is the maximum allowed?"

--- a/db/migrate/20171017154810_add_location_to_time_equipment.rb
+++ b/db/migrate/20171017154810_add_location_to_time_equipment.rb
@@ -1,0 +1,5 @@
+class AddLocationToTimeEquipment < ActiveRecord::Migration[5.1]
+  def change
+    add_column :research_sessions, :location, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171005095604) do
+ActiveRecord::Schema.define(version: 20171017154810) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 20171005095604) do
     t.decimal "other_expenses_limit"
     t.boolean "receipts_required", default: true
     t.text "food_provided"
+    t.string "location"
     t.index ["status"], name: "index_research_sessions_on_status"
   end
 

--- a/features/step_definitions/question_steps.rb
+++ b/features/step_definitions/question_steps.rb
@@ -71,6 +71,8 @@ When(/^I provide full session details for every step$/) do
   end
   @session_duration = '5 minutes'
   fill_in 'How long will the session be? (optional)', with: @session_duration
+  @session_location = 'Rockford House, Leeds'
+  fill_in 'Where will the session be? (optional)', with: @session_location
   @what_to_bring = 'Nothing'
   fill_in 'What do participants need to bring? (optional)', with: @what_to_bring
   Percy::Capybara.snapshot(page, name: :time_equipment)

--- a/features/step_definitions/question_steps.rb
+++ b/features/step_definitions/question_steps.rb
@@ -69,8 +69,10 @@ When(/^I provide full session details for every step$/) do
     select '11', from: 'research_session_start_datetime_4i', visible: false
     select '30', from: 'research_session_start_datetime_5i', visible: false
   end
-  fill_in 'How long will the session be? (optional)', with: '5 minutes'
-  fill_in 'What do participants need to bring? (optional)', with: 'Nothing'
+  @session_duration = '5 minutes'
+  fill_in 'How long will the session be? (optional)', with: @session_duration
+  @what_to_bring = 'Nothing'
+  fill_in 'What do participants need to bring? (optional)', with: @what_to_bring
   Percy::Capybara.snapshot(page, name: :time_equipment)
   click_button 'Continue'
 

--- a/features/support/preview_checker.rb
+++ b/features/support/preview_checker.rb
@@ -46,6 +46,7 @@ module PreviewChecker
     expect(page.body).to include('The session is on')
     expect(page).to have_tag('a.editable', text: /May 10, 2017.*at.*11:30AM/m)
     expect(page).to have_tag('a.editable', text: @session_duration)
+    expect(page).to have_tag('a.editable', text: @session_location)
     expect(page).to have_tag('a.editable', text: @what_to_bring)
   end
 


### PR DESCRIPTION
# [Add Location (or service information) to the research session screen](https://trello.com/c/yzOexm0b/175-3-add-location-or-service-information-to-the-research-session-screen)

While acknowledging that time/equipment is now a bad name, add an
optional location to the time/equipment step. We need a DB migration for
this and an associated label in en.yml. The preview has a simple
sentence with a presence check for the optional field.

<img width="675" alt="screen shot 2017-10-17 at 16 59 14" src="https://user-images.githubusercontent.com/194511/31675438-8fc63634-b35c-11e7-9853-b44dc0df76b2.png">
