### PR TITLE
Autofocus first field / hide "skip to content"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * [BUG] - [IE11 shows two arrows on the print area select field](https://trello.com/c/Y55ixqL5/206-ie11-shows-two-arrows-on-the-print-area-select-field)
 * [BUG] - [some page furniture obscuring printed preview](https://trello.com/c/1EKgH3tL/188-2-bug-some-page-furniture-obscuring-printed-preview)
 * [FEATURE] - [Add Location (or service information) to the research session screen](https://trello.com/c/yzOexm0b/175-3-add-location-or-service-information-to-the-research-session-screen)
+* [BUG] - [Tabbing through radio buttons isn't working](https://trello.com/c/dRpWMj0g/220-tabbing-through-radio-buttons-isnt-working)
+* [FEATURE] - [Autofocusing first field](https://trello.com/c/g7JyFg0O/141-3-autofocusing-first-field)
 
 # 0.2.0 / 2017-10-04
 

--- a/app/assets/stylesheets/barnardos/_accessibility.scss
+++ b/app/assets/stylesheets/barnardos/_accessibility.scss
@@ -1,30 +1,12 @@
 @import "barnardos/colours";
 
-.skip-links {
-  background-color: $focus-background;
-}
-
-.skip-links__inner {
-  width: 500px;
-  margin: 0 auto;
-}
-
-.skip-links__link {
-  color: $white;
-  display: inline-block;
-  left: -999em;
-  padding: 8px;
-  position: absolute;
-
-  &:focus {
-    background-color: $focus-background;
-    border: 3px solid $primary-colour;
-    color: $black;
-    outline: 0;
-    position: static;
-  }
-}
-
 .visually-hidden {
-  display: none;
+  position: absolute;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
 }

--- a/app/assets/stylesheets/barnardos/_checkbox.scss
+++ b/app/assets/stylesheets/barnardos/_checkbox.scss
@@ -89,6 +89,7 @@ $outer-ring: $inner-ring + ($ring-size * 3);
   box-shadow: 0 0 0 $inner-ring $white, 0 0 0 $border-ring $black;
 }
 
+.checkbox-group__input:checked:hover + .checkbox-group__label::before,
 .checkbox-group__input:checked:focus + .checkbox-group__label::before {
   background-color: $primary;
   box-shadow: 0 0 0 $inner-ring $grey-medium, 0 0 0 $border-ring $black, 0 0 0 $outer-ring $grey-medium;

--- a/app/assets/stylesheets/barnardos/_progress.scss
+++ b/app/assets/stylesheets/barnardos/_progress.scss
@@ -3,6 +3,7 @@
 
 .progress {
   margin: ($gutter * 2) ($gutter / 2) ($gutter * 4);
+  max-width: $max-content-width;
 
   @media (min-width: $tablet) {
     margin: ($gutter * 2) 0;

--- a/app/assets/stylesheets/barnardos/_radio.scss
+++ b/app/assets/stylesheets/barnardos/_radio.scss
@@ -56,7 +56,8 @@ $outer-ring: $inner-ring + ($ring-size * 3);
 }
 
 .radio-group__input {
-  display: none;
+  opacity: 0;
+  position: absolute;
 }
 
 .radio-group__input + .radio-group__label {
@@ -78,19 +79,21 @@ $outer-ring: $inner-ring + ($ring-size * 3);
   width: $base-font-size;
 }
 
-.radio-group__input:hover + .radio-group__label::before {
+.radio-group__input:hover + .radio-group__label::before,
+.radio-group__input:focus + .radio-group__label::before {
   background: $grey-medium;
-  box-shadow: 0 0 0 $inner-ring $grey-medium, 0 0 0 $border-ring $black, 0 0 0 $outer-ring $grey-medium;
-}
-
-.radio-group__input:checked:hover + .radio-group__label::before {
-  background: $primary;
   box-shadow: 0 0 0 $inner-ring $grey-medium, 0 0 0 $border-ring $black, 0 0 0 $outer-ring $grey-medium;
 }
 
 .radio-group__input:checked + .radio-group__label::before {
   background-color: $primary;
   box-shadow: 0 0 0 $inner-ring $white, 0 0 0 $border-ring $black;
+}
+
+.radio-group__input:checked:hover + .radio-group__label::before,
+.radio-group__input:checked:focus + .radio-group__label::before {
+  background: $primary;
+  box-shadow: 0 0 0 $inner-ring $grey-medium, 0 0 0 $border-ring $black, 0 0 0 $outer-ring $grey-medium;
 }
 
 .radio-group__input:disabled + .radio-group__label::before {

--- a/app/helpers/barnardos/action_view/form_helper.rb
+++ b/app/helpers/barnardos/action_view/form_helper.rb
@@ -104,11 +104,14 @@ module Barnardos
           )
 
           collection = Array(collection)
+          on_first_item = true
           buttons = collection_radio_buttons(
             object, method, collection, :first, :last, options
           ) do |b|
+            should_autofocus = options[:autofocus_first_item] && on_first_item
+            on_first_item = false
             content_tag :div, class: 'radio-group__choice' do
-              b.radio_button(class: 'radio-group__input') +
+              b.radio_button(class: 'radio-group__input', autofocus: should_autofocus) +
                 b.label(class: 'radio-group__label')
             end
           end

--- a/app/helpers/barnardos/action_view/form_helper.rb
+++ b/app/helpers/barnardos/action_view/form_helper.rb
@@ -141,12 +141,15 @@ module Barnardos
           # will use a straight `include?` to check for checked values. to_s it here
           # This map will deal with both Hash and Array
           collection = collection.map { |k, v| [k.to_s, v] }
+          on_first_item = true
           concat(
             collection_check_boxes(
               object_name, method, collection, :first, :last, options
             ) do |b|
+              should_autofocus = options[:autofocus_first_item] && on_first_item
+              on_first_item = false
               content_tag :div, class: 'checkbox-group__choice' do
-                b.check_box(class: 'checkbox-group__input') +
+                b.check_box(class: 'checkbox-group__input', autofocus: should_autofocus) +
                   b.label(class: 'checkbox-group__label')
               end
             end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,6 +32,7 @@
 </div>
 
 <main id="main" role="main">
+  <%= yield :progress %>
   <div id="content">
     <%= yield %>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,10 +14,8 @@
 <body>
 <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
-<div class="skip-links">
-  <div class="skip-links__inner">
-    <a href="#content" class="skip-links__link">Skip to main content</a>
-  </div>
+<div class="visually-hidden">
+  <a href="#content">Skip to main content</a>
 </div>
 
 <header role="banner" id="global-header">

--- a/app/views/research_sessions/_progress.html.erb
+++ b/app/views/research_sessions/_progress.html.erb
@@ -1,5 +1,5 @@
 <% preview ||= false %>
-
+<%= content_for :progress do %>
 <div class="progress screen-only">
   <ol class="progress-bar">
 
@@ -48,3 +48,4 @@
     </li>
   </ol>
 </div>
+<% end %>

--- a/app/views/research_sessions/data.html.erb
+++ b/app/views/research_sessions/data.html.erb
@@ -7,6 +7,7 @@
     <%= form.radio_group_vertical \
         :shared_with,
         SharedWith::NAME_VALUES,
+        { autofocus_first_item: true },
         legend: 'Who will the data be shared with?'
     %>
 

--- a/app/views/research_sessions/expenses.html.erb
+++ b/app/views/research_sessions/expenses.html.erb
@@ -5,7 +5,7 @@
   <%= barnardos_form_with model: @research_session, url: wizard_path do |form| %>
 
       <%= form.labelled_text_field :travel_expenses_limit,
-            text_options: { placeholder: '0.00' }
+            text_options: { placeholder: '0.00', autofocus: true }
       %>
 
       <%= form.labelled_text_field :food_expenses_limit,

--- a/app/views/research_sessions/incentive.html.erb
+++ b/app/views/research_sessions/incentive.html.erb
@@ -5,6 +5,7 @@
   <%= barnardos_form_with model: @research_session, url: wizard_path do |form| %>
       <%= form.radio_group_vertical :incentive,
           { true => 'Yes', false => 'No' },
+          { autofocus_first_item: true },
           legend: 'Will an incentive be provided?'
       %>
 

--- a/app/views/research_sessions/methodologies.html.erb
+++ b/app/views/research_sessions/methodologies.html.erb
@@ -6,6 +6,7 @@
       <%= form.checkbox_group_vertical(
             :methodologies,
             Methodologies::NAME_VALUES,
+            { autofocus_first_item: true },
             legend: 'How will you be gathering information?'
           )
       %>

--- a/app/views/research_sessions/purpose.html.erb
+++ b/app/views/research_sessions/purpose.html.erb
@@ -6,7 +6,8 @@
       <%= form.labelled_text_area(
             :purpose,
             text_options: {
-              placeholder: 'Barnardo’s needs your help so we can...'
+              placeholder: 'Barnardo’s needs your help so we can...',
+              autofocus: true
             }
           )
       %>

--- a/app/views/research_sessions/recording.html.erb
+++ b/app/views/research_sessions/recording.html.erb
@@ -6,6 +6,7 @@
       <%= form.checkbox_group_vertical(
             :recording_methods,
             RecordingMethods::NAME_VALUES,
+            { autofocus_first_item: true },
             legend: 'How will you be recording information?'
           )
       %>

--- a/app/views/research_sessions/researcher.html.erb
+++ b/app/views/research_sessions/researcher.html.erb
@@ -12,7 +12,8 @@
         and their contact details will be included on the information sheet.
       </p>
 
-      <%= form.labelled_text_field :researcher_name %>
+      <%= form.labelled_text_field :researcher_name,
+          text_options: { autofocus: true } %>
       <%= form.labelled_text_field :researcher_phone %>
       <%= form.labelled_text_field :researcher_email %>
     </fieldset>

--- a/app/views/research_sessions/time_equipment.html.erb
+++ b/app/views/research_sessions/time_equipment.html.erb
@@ -6,11 +6,13 @@
 
     <fieldset class="datefield" id="start_datetime">
       <legend class="datefield__label">Please enter the time and date of the session (optional)</legend>
-      <%= form.datetime_select :start_datetime, {
-        :include_blank => true,
-        :default => nil,
-        minute_step: 15
-      } %>
+      <%=
+        form.datetime_select :start_datetime, {
+          include_blank: true,
+          default: nil,
+          minute_step: 15
+        }
+      %>
     </fieldset>
 
     <%= form.labelled_text_field :duration %>

--- a/app/views/research_sessions/topic.html.erb
+++ b/app/views/research_sessions/topic.html.erb
@@ -6,7 +6,8 @@
       <%= form.labelled_text_area \
           :topic,
           text_options: {
-              placeholder: 'The topic of the project is...'
+              placeholder: 'The topic of the project is...',
+              autofocus: true
           }
       %>
 

--- a/spec/helpers/barnardos/action_view/form_helper_spec.rb
+++ b/spec/helpers/barnardos/action_view/form_helper_spec.rb
@@ -224,6 +224,7 @@ RSpec.describe Barnardos::ActionView::FormHelper, type: :helper do
 
     let(:legend)         { 'My legend' }
     let(:legend_options) { { class: 'my-legend-class' } }
+    let(:options)        { {} }
 
     let(:collection) do
       HashWithIndifferentAccess.new(
@@ -235,7 +236,7 @@ RSpec.describe Barnardos::ActionView::FormHelper, type: :helper do
 
     subject(:rendered) do
       helper.radio_group_vertical(
-        :research_session, :shared_with, collection,
+        :research_session, :shared_with, collection, options,
         legend: legend, legend_options: legend_options
       )
     end
@@ -299,6 +300,37 @@ RSpec.describe Barnardos::ActionView::FormHelper, type: :helper do
 
       it_behaves_like 'it has a legend'
       it_behaves_like 'it has correctly classed and labelled input'
+    end
+
+    describe 'the option :autofocus_first_item' do
+      context 'autofocus_first_item is false' do
+        let(:options) { { autofocus_first_item: false } }
+
+        it 'does not autofocus any checkbox' do
+          expect(rendered).not_to have_tag(
+            'input[autofocus]'
+          )
+        end
+      end
+
+      context 'autofocus_first_item is true' do
+        let(:options) { { autofocus_first_item: true } }
+
+        it 'applies autofocus to the first radio button' do
+          expect(rendered).to have_tag(
+            '.radio-group__choice:nth-of-type(1) > input[autofocus]'
+          )
+        end
+
+        it 'does not apply autofocus to the rest of the radios' do
+          expect(rendered).not_to have_tag(
+            '.radio-group__choice:nth-of-type(2) > input[autofocus]'
+          )
+          expect(rendered).not_to have_tag(
+            '.radio-group__choice:nth-of-type(3) > input[autofocus]'
+          )
+        end
+      end
     end
 
     context 'an error is on the model' do

--- a/spec/helpers/barnardos/action_view/form_helper_spec.rb
+++ b/spec/helpers/barnardos/action_view/form_helper_spec.rb
@@ -322,6 +322,7 @@ RSpec.describe Barnardos::ActionView::FormHelper, type: :helper do
 
     let(:legend)         { 'My legend' }
     let(:legend_options) { {} }
+    let(:options)        { {} }
     let(:collection) do
       {
         interview: 'Interview',
@@ -336,7 +337,7 @@ RSpec.describe Barnardos::ActionView::FormHelper, type: :helper do
 
     subject(:rendered) do
       helper.checkbox_group_vertical(
-        :research_session, :methodologies, collection,
+        :research_session, :methodologies, collection, options,
         legend: legend, legend_options: legend_options
       )
     end
@@ -416,6 +417,37 @@ RSpec.describe Barnardos::ActionView::FormHelper, type: :helper do
         expect(rendered).to have_tag(
           'legend.checkbox-group__legend span.checkbox-group__hint', text: 'A hint'
         )
+      end
+    end
+
+    describe 'the option :autofocus_first_item' do
+      context 'autofocus_first_item is false' do
+        let(:options) { { autofocus_first_item: false } }
+
+        it 'does not autofocus any checkbox' do
+          expect(rendered).not_to have_tag(
+            'input[autofocus]'
+          )
+        end
+      end
+
+      context 'autofocus_first_item is true' do
+        let(:options) { { autofocus_first_item: true } }
+
+        it 'applies autofocus to the first checkbox' do
+          expect(rendered).to have_tag(
+            '.checkbox-group__choice:nth-of-type(1) > input[autofocus]'
+          )
+        end
+
+        it 'does not apply autofocus to the rest of the checkboxes' do
+          expect(rendered).not_to have_tag(
+            '.checkbox-group__choice:nth-of-type(2) > input[autofocus]'
+          )
+          expect(rendered).not_to have_tag(
+            '.checkbox-group__choice:nth-of-type(3) > input[autofocus]'
+          )
+        end
       end
     end
 


### PR DESCRIPTION
# [Autofocus first field](https://trello.com/c/g7JyFg0O/141-3-autofocusing-first-field)

Improves keyboard navigation by placing you in the first field on each form (excepting time/equipment, for which there is a separate [card](https://trello.com/c/91fUZw28/189-3-change-the-date-time-form-fields-to-not-use-formdatetimeselect))

Hides the "skip to main content" link, although it is still in the tab order for screen readers.

We needed to add a radio button focus style, which we had previously done for check boxes, so this PR also fixes [radio buttons not appearing in tab order](https://trello.com/c/dRpWMj0g/220-tabbing-through-radio-buttons-isnt-working).