### PR TITLE
Swapped session date field for simple text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [FEATURE] - [Add Location (or service information) to the research session screen](https://trello.com/c/yzOexm0b/175-3-add-location-or-service-information-to-the-research-session-screen)
 * [BUG] - [Tabbing through radio buttons isn't working](https://trello.com/c/dRpWMj0g/220-tabbing-through-radio-buttons-isnt-working)
 * [FEATURE] - [Autofocusing first field](https://trello.com/c/g7JyFg0O/141-3-autofocusing-first-field)
+* [FEATURE] - [Change the date time form fields to not use `form.datetime_select`](https://trello.com/c/91fUZw28/189-3-change-the-date-time-form-fields-to-not-use-formdatetimeselect)
 
 # 0.2.0 / 2017-10-04
 

--- a/app/models/research_session/steps.rb
+++ b/app/models/research_session/steps.rb
@@ -12,7 +12,7 @@ class ResearchSession
       methodologies: [:other_methodology, methodologies: []],
       recording:     [:other_recording_method, recording_methods: []],
       data:          [:shared_with, :shared_duration, :shared_use],
-      time_equipment: [:start_datetime, :duration, :location, :participant_equipment],
+      time_equipment: [:when_text, :duration, :location, :participant_equipment],
       expenses:      [:travel_expenses_limit, :food_expenses_limit, :other_expenses_limit,
                       :receipts_required, :food_provided],
       incentive:     [:incentive, :payment_type, :incentive_value]

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -117,15 +117,14 @@
       <p>The session will be held at <%= edit_link_for(:location) %>.</p>
     <% end %>
   </section>
-  <% if @research_session.start_datetime.present? or @research_session.duration.present? %>
+  <% if @research_session.when_text.present? or @research_session.duration.present? %>
     <section>
       <h3 class="subtitle-small" id="private">When is the session and what should <%= @research_session.able_to_consent? ? 'I' : 'my child/the child in my care' %> bring?</h3>
         <p>
-          <% if @research_session.start_datetime %>
+          <% if @research_session.when_text %>
             The session is on
-            <%= edit_link_for(:start_datetime) do %>
-              <strong><%= @research_session.start_datetime.strftime("%B %d, %Y") %></strong> at
-              <strong><%= @research_session.start_datetime.strftime("%I:%M%p") %></strong>.
+            <%= edit_link_for(:when_text) do %>
+              <strong><%= @research_session.when_text %></strong>.
             <% end %>
           <% end %>
           <% if @research_session.duration.present? %>

--- a/app/views/research_sessions/time_equipment.html.erb
+++ b/app/views/research_sessions/time_equipment.html.erb
@@ -4,14 +4,14 @@
   <h1 class="subtitle-large">Time and equipment</h1>
   <%= barnardos_form_with model: @research_session, url: wizard_path do |form| %>
 
-    <fieldset class="datefield" id="start_datetime">
+    <fieldset class="datefield">
       <legend class="datefield__label">Please enter the time and date of the session (optional)</legend>
-      <%=
-        form.datetime_select :start_datetime, {
-          include_blank: true,
-          default: nil,
-          minute_step: 15
-        }
+      <%= form.labelled_text_field \
+               :when_text,
+               text_options: {
+                 placeholder: 'Monday 27th September 2017 at 3:00pm',
+                 autofocus: true
+               }
       %>
     </fieldset>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,7 @@ en:
     other_methodology: "What is the other methodology?"
     recording_methods: "How will you be recording information?"
     other_recording_method: "What is the other recording method?"
+    when_text: "The session is held on (optional)"
     duration: "How long will the session be? (optional)"
     location: "Where will the session be? (optional)"
     participant_equipment: "What do participants need to bring? (optional)"

--- a/db/migrate/20171019140044_replace_session_date_time_with_text.rb
+++ b/db/migrate/20171019140044_replace_session_date_time_with_text.rb
@@ -1,0 +1,38 @@
+class ReplaceSessionDateTimeWithText < ActiveRecord::Migration[5.1]
+  def up
+    add_column :research_sessions, :when_text, :string
+    ResearchSession.find_in_batches do |group|
+      group.each do |session|
+        next if session.start_datetime.nil?
+        session.update_attribute(
+          :when_text,
+          session.start_datetime.strftime(
+            "%A #{session.start_datetime.day.ordinalize} %B %Y at %I:%M%p"
+          )
+        )
+      end
+      remove_column :research_sessions, :start_datetime
+    end
+  end
+
+  def down
+    add_column :research_sessions, :start_datetime, :datetime
+    ResearchSession.find_in_batches do |group|
+      group.each do |session|
+        next if session.when_text.nil?
+        new_datetime = begin
+          DateTime.strptime(session.when_text.gsub(/rd|th|st| at/, ''), '%A %e %B %Y %I:%M%p')
+        rescue ArgumentError
+          puts "ResearchSession##{session.id} couldn't parse when_text #{session.when_text}"
+          nil
+        end
+
+        session.update_attribute(
+          :start_datetime,
+          new_datetime
+        )
+      end
+    end
+    remove_column :research_sessions, :when_text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171017154810) do
+ActiveRecord::Schema.define(version: 20171019140044) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,7 +36,6 @@ ActiveRecord::Schema.define(version: 20171017154810) do
     t.string "shared_with"
     t.string "shared_duration"
     t.text "shared_use"
-    t.datetime "start_datetime"
     t.string "duration"
     t.text "participant_equipment"
     t.decimal "travel_expenses_limit"
@@ -45,6 +44,7 @@ ActiveRecord::Schema.define(version: 20171017154810) do
     t.boolean "receipts_required", default: true
     t.text "food_provided"
     t.string "location"
+    t.string "when_text"
     t.index ["status"], name: "index_research_sessions_on_status"
   end
 

--- a/features/step_definitions/question_steps.rb
+++ b/features/step_definitions/question_steps.rb
@@ -62,13 +62,8 @@ When(/^I provide full session details for every step$/) do
   Percy::Capybara.snapshot(page, name: :data)
   click_button 'Continue'
 
-  within '#start_datetime' do
-    select '2017', from: 'research_session_start_datetime_1i', visible: false
-    select 'May', from: 'research_session_start_datetime_2i', visible: false
-    select '10', from: 'research_session_start_datetime_3i', visible: false
-    select '11', from: 'research_session_start_datetime_4i', visible: false
-    select '30', from: 'research_session_start_datetime_5i', visible: false
-  end
+  @held_on = '27th September at 2pm'
+  fill_in 'The session is held on (optional)', with: @held_on
   @session_duration = '5 minutes'
   fill_in 'How long will the session be? (optional)', with: @session_duration
   @session_location = 'Rockford House, Leeds'
@@ -163,14 +158,8 @@ And(/^I fill in the remaining steps$/) do
   fill_in 'How will the data be used?', with: 'Create better outcomes for more children'
   click_button 'Continue'
 
-  within '#start_datetime' do
-    select '2017', from: 'research_session_start_datetime_1i', visible: false
-    select 'May', from: 'research_session_start_datetime_2i', visible: false
-    select '10', from: 'research_session_start_datetime_3i', visible: false
-    select '11', from: 'research_session_start_datetime_4i', visible: false
-    select '30', from: 'research_session_start_datetime_5i', visible: false
-  end
-
+  @held_on = '27th September at 2pm'
+  fill_in 'The session is held on (optional)', with: @held_on
   @session_duration = '5 minutes'
   fill_in 'How long will the session be? (optional)', with: @session_duration
   @what_to_bring = 'Nothing'

--- a/features/support/preview_checker.rb
+++ b/features/support/preview_checker.rb
@@ -44,9 +44,9 @@ module PreviewChecker
 
   def check_time_equipment
     expect(page.body).to include('The session is on')
-    expect(page).to have_tag('a.editable', text: /May 10, 2017.*at.*11:30AM/m)
     expect(page).to have_tag('a.editable', text: @session_duration)
     expect(page).to have_tag('a.editable', text: @session_location)
+    expect(page).to have_tag('a.editable', text: @held_on)
     expect(page).to have_tag('a.editable', text: @what_to_bring)
   end
 

--- a/spec/factories/research_session.rb
+++ b/spec/factories/research_session.rb
@@ -41,7 +41,7 @@ FactoryGirl.define do
     trait :step_time_equipment do
       step_data
       status :time_equipment
-      start_datetime DateTime.parse('1st Sep 2017')
+      when_text '1st Sep 2017'
       duration '1 week'
       participant_equipment 'A coat'
     end

--- a/spec/views/research_session/preview.html.erb_spec.rb
+++ b/spec/views/research_session/preview.html.erb_spec.rb
@@ -21,7 +21,7 @@ describe 'research_sessions/preview' do
     render
   end
   context 'no date or duration is given' do
-    let(:extra_attrs) { { start_datetime: nil, duration: nil } }
+    let(:extra_attrs) { { when_text: nil, duration: nil } }
 
     it 'does not show the date or time' do
       expect(rendered).not_to include('When is the session and what should I bring?')
@@ -29,7 +29,7 @@ describe 'research_sessions/preview' do
   end
 
   context 'no date is given, but a duration is given' do
-    let(:extra_attrs) { { start_datetime: nil, duration: 'Three minutes' } }
+    let(:extra_attrs) { { when_text: nil, duration: 'Three minutes' } }
 
     it 'does not show the date or time' do
       expect(rendered).not_to match('The session is on')
@@ -41,10 +41,10 @@ describe 'research_sessions/preview' do
   end
 
   context 'no duration is given, but a date is given' do
-    let(:extra_attrs) { { start_datetime: DateTime.parse('27 Sep 2017'), duration: nil } }
+    let(:extra_attrs) { { when_text: '27th September 2017', duration: nil } }
 
     it 'shows the date and time' do
-      expect(rendered).to match(/The session is on.*September 27, 2017/m)
+      expect(rendered).to match(/The session is on.*27th September 2017/m)
     end
 
     it 'does not show the duration' do


### PR DESCRIPTION
# [Change the date time form fields to not use `form.datetime_select`](https://trello.com/c/91fUZw28/189-3-change-the-date-time-form-fields-to-not-use-formdatetimeselect)

Remove the date type `start_datetime` attribute and replace it with a
simpler `when_text` field. Autofocus that field and add a label for it in
`en.yml`.

Comes with a complicated two-way migration to generate nice-looking text
from the old dates and perform best efforts to roll back should that be
required.

All the work is pretty much making the tests pass.

Result:
![image](https://user-images.githubusercontent.com/893208/31783793-69992d58-b4f7-11e7-841a-04a25dfa99c3.png)
![image](https://user-images.githubusercontent.com/893208/31783819-83face86-b4f7-11e7-9a5a-3fea048e8201.png)
