### PR TITLE
Style the links and highlights on the preview page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [BUG] - [Tabbing through radio buttons isn't working](https://trello.com/c/dRpWMj0g/220-tabbing-through-radio-buttons-isnt-working)
 * [FEATURE] - [Autofocusing first field](https://trello.com/c/g7JyFg0O/141-3-autofocusing-first-field)
 * [FEATURE] - [Change the date time form fields to not use `form.datetime_select`](https://trello.com/c/91fUZw28/189-3-change-the-date-time-form-fields-to-not-use-formdatetimeselect)
+* [BUG] - [Style the links and highlights on the preview page](https://trello.com/c/DI8wiPw2/110-spike-style-the-links-and-highlights-on-the-preview-page)
 
 # 0.2.0 / 2017-10-04
 

--- a/app/assets/stylesheets/app/session_preview.scss
+++ b/app/assets/stylesheets/app/session_preview.scss
@@ -1,4 +1,10 @@
-.editable,
-.editable > p {
+.editable {
+  display: inline-block;
   background: $highlight-background-colour;
+  padding: .2em;
+
+  // TODO: Remove `> p` when topic and purpose are no longer useing `simple_format`
+  > p {
+    margin: 0;
+  }
 }

--- a/app/assets/stylesheets/barnardos/_colours.scss
+++ b/app/assets/stylesheets/barnardos/_colours.scss
@@ -20,4 +20,4 @@ $grey-medium: #ddd;
 $primary: #49671e;
 $primary-select: #2e4113;
 
-$highlight-background-colour: $orange;
+$highlight-background-colour: #f7ea99;

--- a/app/helpers/research_sessions_helper.rb
+++ b/app/helpers/research_sessions_helper.rb
@@ -11,6 +11,16 @@ module ResearchSessionsHelper
             class: 'editable'
   end
 
+  def methodology_lookup(methodology)
+    consent_translation_key =
+      @research_session.able_to_consent? ? 'able_to_consent' : 'unable_to_consent'
+    if methodology.to_s == 'other'
+      @research_session.other_methodology
+    else
+      I18n.t("report.#{consent_translation_key}.#{methodology}")
+    end
+  end
+
   def you_or_your_child
     @research_session.able_to_consent? ? 'you' : 'your child/the child in your care'
   end

--- a/app/presenters/research_session_presenter.rb
+++ b/app/presenters/research_session_presenter.rb
@@ -21,19 +21,6 @@ class ResearchSessionPresenter
     !@able_to_consent
   end
 
-  def methodology_list
-    consent_translation_key = @able_to_consent ? 'able_to_consent' : 'unable_to_consent'
-    paras = research_session.methodologies.map do |methodology|
-      translation = if methodology.to_s == 'other'
-                      other_methodology
-                    else
-                      I18n.t("report.#{consent_translation_key}.#{methodology}")
-                    end
-      "<p class='highlight'>#{translation}</p>"
-    end
-    paras.join("\n").html_safe
-  end
-
   def recording_methods_list
     lowercase_words = research_session.recording_methods.map do |method|
       if method.to_s == 'other'

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -64,8 +64,12 @@
   <section>
     <h3 class="subtitle-small" id="what">What will happen next?</h3>
 
-    <%= edit_link_for(:methodologies) do %>
-      <%= @research_session.methodology_list %>
+    <% @research_session.methodologies.each do |methodology| %>
+      <p>
+        <%= edit_link_for(:methodologies) do %>
+          <%= methodology_lookup(methodology) %>
+        <% end %>
+      </p>
     <% end %>
     <p>
       With your permission we will record <%= @research_session.unable_to_consent? ? 'your childʼs/the child in your care‘s' : 'the' %> session using

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -32,17 +32,19 @@
   <section>
     <h3 class="subtitle-small" id="why">Why is the research being done?</h3>
 
-    <p>
+    <div>
       <%= edit_link_for(:topic) do %>
         <%= simple_format(@research_session.topic) %>
       <% end %>
-    </p>
+    </div>
 
-    <p>
+    <br>
+
+    <div>
       <%= edit_link_for(:purpose) do %>
         <%= simple_format(@research_session.purpose) %>
       <% end %>
-    </p>
+    </div>
 
     <p>
       It is important that we test the current and future tools and services that

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,13 +92,13 @@ en:
       observation: 'You will be observed carrying out tasks within your normal role'
 
     unable_to_consent:
-      interview: 'Your child will be interviewed and asked your views regarding the project being researched.'
+      interview: 'Your child will be interviewed and asked their views regarding the project being researched.'
       usability: "Your child will be asked to do several short tasks using a website while our researcher watches, listens and takes notes.
         Your child will need to think out loud as they work so that the researcher can understand what they're doing and why.
-        You will also be asked questions about your experience and perceptions of the website.
+        Your child also be asked questions about their experience and perceptions of the website.
         The session will last no longer than one hour."
-      survey: 'You will be asked to answer a series of questions related to this project.'
-      focusgroup: 'You will be asked to take part in a discussion with our researcher and other volunteers'
-      codesign: 'You will take part in a short, intense, session lasting around 3 hours, with a number of other participants. During
-        this time you will discuss idea and needs for a service or product and help formalise a solution and next steps.'
-      observation: 'You will be observed carrying out tasks within your normal role'
+      survey: 'Your child will be asked to answer a series of questions related to this project.'
+      focusgroup: 'Your child will be asked to take part in a discussion with our researcher and other volunteers'
+      codesign: 'Your child will take part in a short, intense, session lasting around 3 hours, with a number of other participants. During
+        this time they will discuss idea and needs for a service or product and help formalise a solution and next steps.'
+      observation: 'Your child will be observed carrying out tasks within their normal role'

--- a/spec/helpers/research_sessions_helper_spec.rb
+++ b/spec/helpers/research_sessions_helper_spec.rb
@@ -44,4 +44,46 @@ RSpec.describe ResearchSessionsHelper, :type => :helper do
       end
     end
   end
+
+  describe '#methodology_lookup' do
+    let(:research_session) { double('ResearchSession') }
+
+    let(:able_to_consent) { true }
+    let(:methodology) { 'interview' }
+    before do
+      allow(research_session).to receive(:able_to_consent?).and_return(able_to_consent)
+      assign(:research_session, research_session)
+    end
+
+    subject(:translation) { helper.methodology_lookup(methodology) }
+
+    context 'participants are unable to consent' do
+      let(:able_to_consent) { false }
+      it 'returns a child-appropriate translation' do
+        expect(translation).to eql(
+          'Your child will be interviewed ' \
+          'and asked their views regarding the project being researched.'
+        )
+      end
+    end
+
+    context 'participants are able to consent' do
+      let(:able_to_consent) { true }
+      it 'returns a adult-appropriate translation' do
+        expect(translation).to eql(
+          'You will be interviewed ' \
+          'and asked your views regarding the project being researched.'
+        )
+      end
+    end
+
+    context 'the research session contains "other"' do
+      let(:methodology) { 'other' }
+      before { allow(research_session).to receive(:other_methodology).and_return('Reiki') }
+
+      it 'has asked the research session for the translation' do
+        expect(translation).to eql('Reiki')
+      end
+    end
+  end
 end

--- a/spec/presenters/research_session_presenter_spec.rb
+++ b/spec/presenters/research_session_presenter_spec.rb
@@ -38,49 +38,6 @@ RSpec.describe ResearchSessionPresenter do
     end
   end
 
-  describe '#methodology_list' do
-    let(:methodologies) { [:interview, :usability] }
-    before do
-      allow(research_session).to receive(:methodologies).and_return(methodologies)
-    end
-
-    subject(:list) { presenter.methodology_list }
-
-    context 'participants are unable to consent' do
-      let(:able_to_consent) { false }
-      it 'has as many paragraphs as there are methodologies' do
-        expect(list).to have_tag('p', count: 2)
-      end
-      it 'assembles a child-appropriate list of methodology segments' do
-        expect(list).to include('Your child will be interviewed')
-        expect(list).to include('Your child will be asked')
-      end
-      it 'is html_safe' do
-        expect(list).to be_html_safe
-      end
-    end
-
-    context 'participants are able to consent' do
-      let(:able_to_consent) { true }
-      it 'has as many paragraphs as there are methodologies' do
-        expect(list).to have_tag('p', count: 2)
-      end
-      it 'assembles an adult-appropriate list of methodology segments' do
-        expect(list).to include('You will be interviewed')
-        expect(list).to include('You will be asked')
-      end
-
-      context 'the research session contains "other"' do
-        let(:methodologies) { [:interview, :usability, :other] }
-        before { allow(research_session).to receive(:other_methodology).and_return('Reiki') }
-
-        it 'has it all' do
-          expect(list).to include('Reiki')
-        end
-      end
-    end
-  end
-
   describe '#recording_methods_list' do
     let(:other_recording_method) { nil }
 


### PR DESCRIPTION
# [Style the links and highlights on the preview page](https://trello.com/c/DI8wiPw2/110-spike-style-the-links-and-highlights-on-the-preview-page)

Style the highlight edit links on the preview page to not be so harsh. This will make the final preview page easier to read for the users. Also removed empty html that was being outputted.

After:
![image](https://user-images.githubusercontent.com/893208/32106671-3bfc6fee-bb24-11e7-8a7b-80c0264264dd.png)

Before:
![image](https://user-images.githubusercontent.com/893208/32106697-49c5b446-bb24-11e7-9e10-b9cc092d17f8.png)
