### PR TITLE
Change FactoryGirl to FactoryBot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ group :test do
   gem 'cucumber-rails', require: false
   gem 'database_cleaner'
   gem 'launchy'
-  gem 'factory_girl_rails'
+  gem 'factory_bot_rails'
   gem 'danger'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,10 +100,10 @@ GEM
     diff-lcs (1.3)
     erubi (1.6.1)
     execjs (2.7.0)
-    factory_girl (4.8.0)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.8.0)
-      factory_girl (~> 4.8.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
@@ -279,7 +279,7 @@ DEPENDENCIES
   cucumber-rails
   danger
   database_cleaner
-  factory_girl_rails
+  factory_bot_rails
   jbuilder (~> 2.5)
   launchy
   listen (>= 3.0.5, < 3.2)

--- a/spec/factories/research_session.rb
+++ b/spec/factories/research_session.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :research_session do
     trait :step_researcher do
       status :researcher

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,3 +1,3 @@
 RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
While the etymology of FactoryGirl might have been innocent enough,
let's not pretend we can hire for diversity while knowingly
perpetuating a harmful stereotype. Go gender-neutral, it makes things
better.

And thanks, ThoughtBot, for being ThoughtfulBot.

https://github.com/thoughtbot/factory_bot/blob/master/NAME.md