### PR TITLE
Replace stray FactoryGirl reference

### DIFF
--- a/features/step_definitions/named_session_steps.rb
+++ b/features/step_definitions/named_session_steps.rb
@@ -12,7 +12,7 @@ Then(/^I should see that name in the URL$/) do
 end
 
 Given(/^there is an existing session with a name$/) do
-  FactoryGirl.create(:research_session, name: StepCompletions::BULLYING_NAME)
+  FactoryBot.create(:research_session, name: StepCompletions::BULLYING_NAME)
 end
 
 Then(/^I should see a disambiguated name in the URL$/) do


### PR DESCRIPTION
Post-merge of two unrelated PRs (session-naming and factory-bot
branches), we've ended up with a build-breaked stray FactoryGirl
reference.

Replacing it here.