### PR TITLE
Create page titles for each step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.4.0 / Unreleased
 
 * [FEATURE] - [Add location input to where&when](https://trello.com/c/wdLqH6qT/228-1-add-location-input-to-wherewhen)
+* [FEATURE] - [Create page titles for each step](https://trello.com/c/iZY1S1ZC/200-3-create-page-titles-for-each-step)
 
 # 0.3.0 / 2017-10-30
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,9 +10,9 @@ module ApplicationHelper
 
   def title(research_session, step)
     if research_session.nil?
-      'Consent Form Builder'
+      I18n.t('application.title')
     elsif research_session.new_record?
-      'Create a new form – Consent Form Builder'
+      "#{I18n.t('application.create_new_form')} – #{I18n.t('application.title')}"
     elsif research_session.status == 'incentive' && step.nil?
       "Preview – #{research_session.name.strip}"
     else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,4 +7,16 @@ module ApplicationHelper
 
     link_to sha[0..7], COMMIT_STEM + sha
   end
+
+  def title(research_session, step)
+    if research_session.nil?
+      'Consent Form Builder'
+    elsif research_session.new_record?
+      'Create a new form – Consent Form Builder'
+    elsif research_session.status == 'incentive' && step.nil?
+      "Preview – #{research_session.name.strip}"
+    else
+      "#{step.to_s.humanize} – #{research_session.name.strip}"
+    end
+  end
 end

--- a/app/presenters/research_session_presenter.rb
+++ b/app/presenters/research_session_presenter.rb
@@ -11,7 +11,7 @@ class ResearchSessionPresenter
     delegate attribute, to: :research_session
   end
 
-  delegate :reached_step?, to: :research_session
+  delegate :new_record?, :reached_step?, to: :research_session
 
   def able_to_consent?
     @able_to_consent

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title>Consent Form Builder</title>
+  <title><%= title(@research_session, step) %></title>
   <%= csrf_meta_tags %>
   <%= stylesheet_link_tag 'application', media: 'all' %>
   <%= stylesheet_link_tag 'print', media: 'print' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,10 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
+  application:
+    title: 'Consent Form Builder'
+    create_new_form: 'Create a new form'
+
   research_session_attr_labels: &attr_labels
     name: 'Please name your research session'
     shared_duration: "How long will this information be held for?"
@@ -56,6 +60,10 @@ en:
     food_provided: "Will you provide food or refreshments at the session? (optional)"
     incentive: "Will an incentive be provided?"
     payment_type: "What form will the incentive take?"
+
+  pages:
+    research_session:
+      new:
 
   activerecord:
     attributes:

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -43,4 +43,36 @@ RSpec.describe ApplicationHelper, type: :helper do
       it { is_expected.to eql('unavailable') }
     end
   end
+
+  describe '#title' do
+    subject(:title) { helper.title(research_session, step) }
+
+    context 'We are at the start' do
+      let(:step) { nil }
+      let(:research_session) { ResearchSession.new }
+
+      it { is_expected.to eql('Create a new form – Consent Form Builder') }
+    end
+
+    context 'We are at a normal step' do
+      let(:step) { :researcher }
+      let(:research_session) { create :research_session, :step_researcher }
+
+      it { is_expected.to eql('Researcher – My session') }
+    end
+
+    context 'We are at the preview' do
+      let(:step) { nil }
+      let(:research_session) { create :research_session, :previewable }
+
+      it { is_expected.to eql('Preview – My session') }
+    end
+
+    context 'We are not looking at a research session at all' do
+      let(:step) { nil }
+      let(:research_session) { nil }
+
+      it { is_expected.to eql('Consent Form Builder') }
+    end
+  end
 end


### PR DESCRIPTION
# [Create page titles for each step](https://trello.com/c/iZY1S1ZC/200-3-create-page-titles-for-each-step)

Make page titles reflect where we currently are in the process.

This also points out that our "preview" stage is a bit convoluted –
a session will be at the "incentive" step. We don't really have a
"finished" or "preview" state. We should, but that's tech debt.