### PR TITLE
Add copy functionality for copy button

### DIFF
--- a/app/javascript/components/share.js
+++ b/app/javascript/components/share.js
@@ -1,4 +1,6 @@
 /* eslint no-new: 0 */
+const Clipboard = require('clipboard')
+
 class Share {
   constructor (container) {
     this.cacheElements(container)
@@ -25,6 +27,7 @@ class Share {
 
   static init (container = document) {
     new Share(container)
+    new Clipboard('.js-copy-url-button')
   }
 }
 


### PR DESCRIPTION
Fixup 8ba6145 to include the desired copy to clipboard functionality
required for the new share UI.

![image](https://slack-imgs.com/?c=1&url=https%3A%2F%2Fmedia0.giphy.com%2Fmedia%2FiFkHQLzYA09Zm%2Fgiphy-downsized.gif)
