### PR TITLE
Move :food_provided to bottom on where_when step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Rename steps: 'Data' to 'storing', 'Time & equipment' to 'Where & when', and 'Incentive' to 'Incentives'
 * Progress bar should reflect latest design
 * [FEATURE] - [Share / Save consent form session](https://trello.com/c/zU3zqiy1/92-5-share-save-consent-form-session)
+* [BUG] - [Expenses / refreshments improvements](https://trello.com/c/2mT0SkHT/212-2-expenses-refreshments-improvements)
 
 # 0.3.0 / 2017-10-30
 

--- a/app/models/research_session/steps.rb
+++ b/app/models/research_session/steps.rb
@@ -11,9 +11,10 @@ class ResearchSession
       methodologies: [:other_methodology, methodologies: []],
       recording:     [:other_recording_method, recording_methods: []],
       storing:       [:shared_with, :shared_duration, :shared_use],
-      where_when:    [:when_text, :duration, :location, :participant_equipment],
+      where_when:    [:when_text, :duration, :location, :participant_equipment,
+                      :food_provided],
       expenses:      [:travel_expenses_limit, :food_expenses_limit, :other_expenses_limit,
-                      :receipts_required, :food_provided],
+                      :receipts_required],
       incentives:    [:incentive, :payment_type, :incentive_value]
     }]
 

--- a/app/views/research_sessions/expenses.html.erb
+++ b/app/views/research_sessions/expenses.html.erb
@@ -21,8 +21,6 @@
             legend: 'Must the participant provide a receipt for any expenses claimed?'
       %>
 
-      <%= form.labelled_text_area :food_provided %>
-
       <%= render 'button_bar' %>
   <% end %>
 </div>

--- a/app/views/research_sessions/where_when.html.erb
+++ b/app/views/research_sessions/where_when.html.erb
@@ -20,6 +20,8 @@
 
     <%= form.labelled_text_area :participant_equipment %>
 
+    <%= form.labelled_text_area :food_provided %>
+
     <%= render 'button_bar' %>
   <% end %>
 </div>


### PR DESCRIPTION
# [Expenses / refreshments improvements](https://trello.com/c/2mT0SkHT/212-2-expenses-refreshments-improvements)

The :food_provided value does not relate to what the participant can
expense. Move the :food_provided value to the where_when step.