### PR TITLE
Add job title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.5.0 / Unreleased
 
 * [FEATURE] - [Add yes/no radiobuttons on top of Where&When, Expenses and Incentives](https://trello.com/c/Ncnz0D6S/229-2-add-yes-no-radiobuttons-on-top-of-wherewhen-expenses-and-incentives)
+* [FEATURE] - [Researcher page: we should have job title of the lead researcher as a field](https://trello.com/c/HvKi9NwT/169-2-researcher-page-we-should-have-job-title-of-the-lead-researcher-as-a-field)
 
 # 0.4.0 / 2017-11-07
 

--- a/app/models/research_session/steps.rb
+++ b/app/models/research_session/steps.rb
@@ -5,8 +5,9 @@ class ResearchSession
     include Singleton
 
     PARAMS = ActiveSupport::OrderedHash[{
-      researcher:    [:researcher_name, :researcher_phone, :researcher_email,
-                      :researcher_other, :researcher_other_name, :researcher_other_name],
+      researcher:    [:researcher_job_title, :researcher_name, :researcher_phone,
+                      :researcher_email, :researcher_other, :researcher_other_name,
+                      :researcher_other_name],
       topic:         [:topic, :purpose],
       methodologies: [:other_methodology, methodologies: []],
       recording:     [:other_recording_method, recording_methods: []],

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -49,7 +49,11 @@
   <section>
     <h3 class="subtitle-small" id="who">Who is doing the research?</h3>
     <p>
-      <%= edit_link_for(:researcher_name) %> is the researcher who will be leading the session.
+      <%= edit_link_for(:researcher_name) -%>
+      <% if @research_session.researcher_job_title.present? %>
+, <%= edit_link_for(:researcher_job_title) %>
+      <% end %>
+      will be leading the session.
       <% if @research_session.researcher_other_name.present? %>
         <%= edit_link_for(:researcher_name) %>ʼs colleague,
         <%= edit_link_for(:researcher_other_name) %>,

--- a/app/views/research_sessions/questions/researcher.html.erb
+++ b/app/views/research_sessions/questions/researcher.html.erb
@@ -12,8 +12,9 @@
         and their contact details will be included on the information sheet.
       </p>
 
-      <%= form.labelled_text_field :researcher_name,
-          text_options: { autofocus: true } %>
+      <%= form.labelled_text_field :researcher_job_title,
+        text_options: { autofocus: true } %>
+      <%= form.labelled_text_field :researcher_name %>
       <%= form.labelled_text_field :researcher_phone %>
       <%= form.labelled_text_field :researcher_email %>
     </fieldset>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,7 @@ en:
     shared_duration: "How long will this information be held for?"
     shared_use: "How will the data be used?"
     shared_with: "Who will the data be shared with?"
+    researcher_job_title: 'Job title (optional)'
     researcher_name: 'Full name'
     researcher_other_name: 'Full name'
     researcher_phone: 'Telephone number (optional)'

--- a/db/migrate/20171108111544_add_job_title_to_researcher.rb
+++ b/db/migrate/20171108111544_add_job_title_to_researcher.rb
@@ -1,0 +1,5 @@
+class AddJobTitleToResearcher < ActiveRecord::Migration[5.1]
+  def change
+    add_column :research_sessions, :researcher_job_title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 20171109124132) do
     t.string "slug"
     t.boolean "where_when_enabled", default: false
     t.boolean "expenses_enabled", default: false
+    t.string "researcher_job_title"
     t.index ["slug"], name: "index_research_sessions_on_slug", unique: true
     t.index ["status"], name: "index_research_sessions_on_status"
   end

--- a/features/support/preview_checker.rb
+++ b/features/support/preview_checker.rb
@@ -4,6 +4,7 @@
 #
 module PreviewChecker
   def check_researcher
+    expect(page.body).to include('Director of Research')
     expect(page.body).to include('Rachel Researcher')
     expect(page.body).to include('012345678')
     expect(page.body).to include('rachel@researcher.com')

--- a/features/support/step_completions.rb
+++ b/features/support/step_completions.rb
@@ -12,6 +12,7 @@ module StepCompletions
 
   def complete_researcher_step
     within '[name="first-researcher"]' do
+      fill_in 'Job title', with: 'Director of Research'
       fill_in 'Full name', with: 'Rachel Researcher'
       fill_in 'Telephone number', with: '012345678'
       fill_in 'Email', with: 'rachel@researcher.com'


### PR DESCRIPTION
# [Researcher page: we should have job title of the lead researcher as a field](https://trello.com/c/HvKi9NwT/169-2-researcher-page-we-should-have-job-title-of-the-lead-researcher-as-a-field)

As a consent form author
I want to be able to provide researcher job title
so that participant can understand who are they meeting

![image](https://user-images.githubusercontent.com/893208/32547713-4fed49fa-c47b-11e7-83af-6b2a69ecba28.png)
![image](https://user-images.githubusercontent.com/893208/32547728-5957d118-c47b-11e7-9dfd-967be64bf278.png)
