### PR TITLE
Ignore '£' in currency fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [FEATURE] - [Add yes/no radiobuttons on top of Where&When, Expenses and Incentives](https://trello.com/c/Ncnz0D6S/229-2-add-yes-no-radiobuttons-on-top-of-wherewhen-expenses-and-incentives)
 * [FEATURE] - [Researcher page: we should have job title of the lead researcher as a field](https://trello.com/c/HvKi9NwT/169-2-researcher-page-we-should-have-job-title-of-the-lead-researcher-as-a-field)
+* [BUG] - [When a sterling sign is added in, the preview generates 0.00](https://trello.com/c/IHdoFxEl/246-3-bug-when-a-sterling-sign-is-added-in-the-preview-generates-000)
 
 # 0.4.0 / 2017-11-07
 

--- a/app/controllers/research_sessions/questions_controller.rb
+++ b/app/controllers/research_sessions/questions_controller.rb
@@ -42,6 +42,15 @@ module ResearchSessions
       params.require(:research_session).permit(ResearchSession::Steps::PARAMS[step]).tap do |p|
         p['methodologies']&.reject!(&:blank?)
         p['recording_methods']&.reject!(&:blank?)
+
+        %w[
+          travel_expenses_limit
+          food_expenses_limit
+          other_expenses_limit
+          incentive_value
+        ].each do |attr|
+          p[attr] = p[attr].delete('£') if p[attr]
+        end
       end
     end
   end

--- a/app/models/research_session.rb
+++ b/app/models/research_session.rb
@@ -44,9 +44,16 @@ class ResearchSession < ApplicationRecord
   validates :shared_use, presence: true,
             if: -> (session) { session.reached_step?(:storing) }
 
+  validates :travel_expenses_limit, numericality: true,
+            if: -> (session) { session.expenses_enabled && session.reached_step?(:expenses) }
+  validates :food_expenses_limit, numericality: true,
+            if: -> (session) { session.expenses_enabled && session.reached_step?(:expenses) }
+  validates :other_expenses_limit, numericality: true,
+            if: -> (session) { session.expenses_enabled && session.reached_step?(:expenses) }
+
   validates :payment_type, inclusion: { in: PaymentType.allowed_values },
             if: -> (session) { session.incentives_enabled && session.reached_step?(:incentives) }
-  validates :incentive_value, presence: true,
+  validates :incentive_value, presence: true, numericality: true,
             if: -> (session) { session.incentives_enabled && session.reached_step?(:incentives) }
 
   def reached_step?(step)

--- a/spec/controllers/research_sessions/questions_controller_spec.rb
+++ b/spec/controllers/research_sessions/questions_controller_spec.rb
@@ -122,7 +122,30 @@ RSpec.describe ResearchSessions::QuestionsController, type: :controller do
       end
     end
 
-    context 'the last step' do
+    context 'numerical values with currency symbols are given' do
+      let(:existing_step) { :where_when }
+
+      let(:params) do
+        {
+          research_session_id: existing_session.slug,
+          id: 'expenses',
+          research_session: {
+            expenses_enabled: true,
+            travel_expenses_limit: '£10.00',
+            food_expenses_limit: '£10.00',
+            other_expenses_limit: '£10.00'
+          }
+        }
+      end
+
+      it 'saves the numerical values correctly' do
+        expect(research_session.travel_expenses_limit).to eql(10.00)
+        expect(research_session.food_expenses_limit).to eql(10.00)
+        expect(research_session.other_expenses_limit).to eql(10.00)
+      end
+    end
+
+    context 'the last step, incentives' do
       let(:existing_step) { :storing }
 
       let(:params) do
@@ -132,7 +155,7 @@ RSpec.describe ResearchSessions::QuestionsController, type: :controller do
           research_session: {
             incentives_enabled: true,
             payment_type: 'cash',
-            incentive_value: 10.00
+            incentive_value: '£10.00'
           }
         }
       end

--- a/spec/models/research_session_spec.rb
+++ b/spec/models/research_session_spec.rb
@@ -205,6 +205,28 @@ RSpec.describe ResearchSession, type: :model do
         end
       end
 
+      describe 'validating the expenses step' do
+        let(:step) { :expenses }
+
+        context 'expenses provided are not numerical' do
+          let(:set_attrs) do
+            {
+              expenses_enabled: true,
+              travel_expenses_limit: 'roughly £10',
+              food_expenses_limit: 'roughly £10',
+              other_expenses_limit: 'roughly £10'
+            }
+          end
+
+          it { is_expected.not_to be_valid }
+          it 'has error messages' do
+            expect(session.errors[:travel_expenses_limit].first).to eql('is not a number')
+            expect(session.errors[:food_expenses_limit].first).to eql('is not a number')
+            expect(session.errors[:other_expenses_limit].first).to eql('is not a number')
+          end
+        end
+      end
+
       describe 'validating the incentives step' do
         let(:step) { :incentives }
 
@@ -231,13 +253,22 @@ RSpec.describe ResearchSession, type: :model do
 
               it { is_expected.not_to be_valid }
               it 'has an error on incentive_value' do
-                expect(session.errors[:incentive_value].length).to eql(1)
+                expect(session.errors[:incentive_value].length).to eql(2)
                 expect(session.errors[:incentive_value].first).to match(/can't be blank/)
               end
             end
 
             context 'and an incentive_value has been provided' do
               it { is_expected.to be_valid }
+            end
+
+            context 'an invalid incentive_value has been provided' do
+              let(:set_attrs) { { incentive_value: 'roughly £10' } }
+
+              it { is_expected.not_to be_valid }
+              it 'has an error about numericality' do
+                expect(session.errors[:incentive_value].first).to eql('is not a number')
+              end
             end
           end
         end


### PR DESCRIPTION
# [When a sterling sign is added in, the preview generates 0.00](https://trello.com/c/IHdoFxEl/246-3-bug-when-a-sterling-sign-is-added-in-the-preview-generates-000)

> As a user
> I want to be able to use currency character in money fields
> So that it doesn't affect the saved amount

Add validation to currency fields to ensure numerical values are given.
Strip '£' as it is a common use case.