### PR TITLE
GDPR compliance for storing step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [FEATURE] - [Researcher page: we should have job title of the lead researcher as a field](https://trello.com/c/HvKi9NwT/169-2-researcher-page-we-should-have-job-title-of-the-lead-researcher-as-a-field)
 * [BUG] - [When a sterling sign is added in, the preview generates 0.00](https://trello.com/c/IHdoFxEl/246-3-bug-when-a-sterling-sign-is-added-in-the-preview-generates-000)
 * [FEATURE] - [Create a New Form and Info Sheet from a Saved Form and Info Sheet (aka Research Session)](https://trello.com/c/qYBbtDC9/87-create-a-new-form-and-info-sheet-from-a-saved-form-and-info-sheet-aka-research-session)
+* [FEATURE] - [GDPR compliance for our Data (now Storing) step](https://trello.com/c/kkuQxS8T/224-gdpr-compliance-for-our-data-now-storing-step)
 
 # 0.4.0 / 2017-11-07
 

--- a/app/assets/stylesheets/barnardos/_radio.scss
+++ b/app/assets/stylesheets/barnardos/_radio.scss
@@ -18,6 +18,7 @@ $outer-ring: $inner-ring + ($ring-size * 3);
 
 .radio-group__legend {
   margin-top: ($gutter / 2);
+  line-height: 24px;
   color: $black;
   width: 100%;
 

--- a/app/helpers/research_sessions_helper.rb
+++ b/app/helpers/research_sessions_helper.rb
@@ -21,6 +21,10 @@ module ResearchSessionsHelper
     end
   end
 
+  def shared_with_lookup(shared_with)
+    I18n.t("preview.shared_with.#{shared_with}", person: you_or_your_child)
+  end
+
   def you_or_your_child
     @research_session.able_to_consent? ? 'you' : 'your child/the child in your care'
   end

--- a/app/models/research_session.rb
+++ b/app/models/research_session.rb
@@ -41,9 +41,6 @@ class ResearchSession < ApplicationRecord
   validates :shared_duration, presence: true,
             if: -> (session) { session.reached_step?(:storing) }
 
-  validates :shared_use, presence: true,
-            if: -> (session) { session.reached_step?(:storing) }
-
   validates :travel_expenses_limit, numericality: true,
             if: -> (session) { session.expenses_enabled && session.reached_step?(:expenses) }
   validates :food_expenses_limit, numericality: true,

--- a/app/models/research_session/steps.rb
+++ b/app/models/research_session/steps.rb
@@ -11,7 +11,7 @@ class ResearchSession
       topic:         [:topic, :purpose],
       methodologies: [:other_methodology, methodologies: []],
       recording:     [:other_recording_method, recording_methods: []],
-      storing:       [:shared_with, :shared_duration, :shared_use],
+      storing:       [:shared_with, :shared_duration],
       where_when:    [:where_when_enabled, :when_text, :duration, :location, :participant_equipment,
                       :food_provided],
       expenses:      [:expenses_enabled, :travel_expenses_limit, :food_expenses_limit,

--- a/app/models/shared_with.rb
+++ b/app/models/shared_with.rb
@@ -1,8 +1,9 @@
 class SharedWith
   NAME_VALUES = HashWithIndifferentAccess.new(
-    team:     'Just the team',
-    internal: 'Other teams internally',
-    external:  'Other teams externally'
+    anonymised: 'anonymised as we process it',
+    team:       'shared with the research team at Barnardo\'s',
+    internal:   'shared with other teams in Barnardo\'s',
+    external:   'used in external publications'
   )
 
   def self.allowed_values

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -113,6 +113,11 @@
   </section>
   <section>
     <h3 class="subtitle-small" id="private">How will the data be used?</h3>
+    <p>
+      <%= edit_link_for(:shared_with) do %>
+        <%= shared_with_lookup(@research_session.shared_with) %>
+      <% end %>
+    </p>
     <p>The data will be kept for <%= edit_link_for(:shared_duration) %>.</p>
   </section>
   <% if @research_session.where_when_enabled %>

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -113,8 +113,6 @@
   </section>
   <section>
     <h3 class="subtitle-small" id="private">How will the data be used?</h3>
-    <p><%= edit_link_for(:shared_use) %></p>
-
     <p>The data will be kept for <%= edit_link_for(:shared_duration) %>.</p>
   </section>
   <% if @research_session.where_when_enabled %>

--- a/app/views/research_sessions/questions/storing.html.erb
+++ b/app/views/research_sessions/questions/storing.html.erb
@@ -8,7 +8,7 @@
         :shared_with,
         SharedWith::NAME_VALUES,
         { autofocus_first_item: true },
-        legend: 'Who will the data be shared with?'
+        legend: t('helpers.legend.research_session.shared_with')
     %>
 
     <%= form.labelled_text_field \

--- a/app/views/research_sessions/questions/storing.html.erb
+++ b/app/views/research_sessions/questions/storing.html.erb
@@ -13,10 +13,6 @@
 
     <%= form.labelled_text_field :shared_duration %>
 
-    <%= form.labelled_text_area \
-          :shared_use, text_options: { placeholder: 'The data will be used to...' }
-    %>
-
     <%= render 'button_bar' %>
   <% end %>
 </div>

--- a/app/views/research_sessions/questions/storing.html.erb
+++ b/app/views/research_sessions/questions/storing.html.erb
@@ -11,7 +11,15 @@
         legend: 'Who will the data be shared with?'
     %>
 
-    <%= form.labelled_text_field :shared_duration %>
+    <%= form.labelled_text_field \
+        :shared_duration,
+        label_options: {
+          hint: t('helpers.hint.research_session.shared_duration')
+        },
+        text_options: {
+          placeholder: t('helpers.placeholder.research_session.shared_duration'),
+        }
+    %>
 
     <%= render 'button_bar' %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -111,7 +111,7 @@ en:
       internal: "Identifiable recordings, such as photos, videos or voice recordings will be shared no more widely than Barnardo’s internal staff"
       external: "Identifiable recordings, such as photos, videos or voice recordings will be used for external publications, such as reports, press articles or on the website"
 
-  # ugh
+  # this should lose all reference to "report" and be merged into preview
   report:
     able_to_consent:
       interview: 'You will be interviewed and asked your views regarding the project being researched.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,11 +80,15 @@ en:
       research_session:
         topic: "e.g. how young people think of consent and research"
         purpose: "e.g. talk to them in a way that they understand."
+        shared_duration: "2 years"
     legend:
       research_session:
         expenses_enabled: "Will expenses be allowed?"
         incentives_enabled: "Will an incentive be provided?"
         where_when_enabled: "Is time and location specified?"
+    hint:
+      research_session:
+        shared_duration: "We recommend two years after the closure of the project"
 
 
   errors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,6 +86,7 @@ en:
         expenses_enabled: "Will expenses be allowed?"
         incentives_enabled: "Will an incentive be provided?"
         where_when_enabled: "Is time and location specified?"
+        shared_with: "How will the information recorded in this session be stored and processed? Identifiable information will be:"
     hint:
       research_session:
         shared_duration: "We recommend two years after the closure of the project"
@@ -103,6 +104,14 @@ en:
         precision: 2
         format: '%u%n'
 
+  preview:
+    shared_with:
+      anonymised: "Any research recordings will have names and personal details removed and replaced with fictitious names and stock photos before we share the findings from the research. Therefore, %{person} will not be identifiable by the research recordings."
+      team: "Identifiable recordings, such as photos, videos or voice recordings will be shared no more widely than the team undertaking the research."
+      internal: "Identifiable recordings, such as photos, videos or voice recordings will be shared no more widely than Barnardo’s internal staff"
+      external: "Identifiable recordings, such as photos, videos or voice recordings will be used for external publications, such as reports, press articles or on the website"
+
+  # ugh
   report:
     able_to_consent:
       interview: 'You will be interviewed and asked your views regarding the project being researched.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,7 +39,6 @@ en:
   research_session_attr_labels: &attr_labels
     name: 'Please name your research session'
     shared_duration: "How long will this information be held for?"
-    shared_use: "How will the data be used?"
     shared_with: "Who will the data be shared with?"
     researcher_job_title: 'Job title (optional)'
     researcher_name: 'Full name'

--- a/db/migrate/20171116154338_remove_shared_use.rb
+++ b/db/migrate/20171116154338_remove_shared_use.rb
@@ -1,0 +1,5 @@
+class RemoveSharedUse < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :research_sessions, :shared_use, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171109124132) do
+ActiveRecord::Schema.define(version: 20171116154338) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,7 +35,6 @@ ActiveRecord::Schema.define(version: 20171109124132) do
     t.text "purpose"
     t.string "shared_with"
     t.string "shared_duration"
-    t.text "shared_use"
     t.string "duration"
     t.text "participant_equipment"
     t.decimal "travel_expenses_limit"
@@ -47,9 +46,9 @@ ActiveRecord::Schema.define(version: 20171109124132) do
     t.string "when_text"
     t.string "name"
     t.string "slug"
+    t.string "researcher_job_title"
     t.boolean "where_when_enabled", default: false
     t.boolean "expenses_enabled", default: false
-    t.string "researcher_job_title"
     t.index ["slug"], name: "index_research_sessions_on_slug", unique: true
     t.index ["status"], name: "index_research_sessions_on_status"
   end

--- a/features/support/preview_checker.rb
+++ b/features/support/preview_checker.rb
@@ -37,6 +37,9 @@ module PreviewChecker
 
   def check_storing
     expect(page).to have_tag('p', text: "The data will be kept for #{@shared_duration}.")
+    expect(page).to have_content(
+      'Any research recordings will have names and personal details removed and replaced'
+    )
   end
 
   def check_where_when

--- a/features/support/preview_checker.rb
+++ b/features/support/preview_checker.rb
@@ -37,7 +37,6 @@ module PreviewChecker
 
   def check_storing
     expect(page).to have_tag('p', text: "The data will be kept for #{@shared_duration}.")
-    expect(page).to have_tag('p', text: @shared_usage)
   end
 
   def check_where_when

--- a/features/support/step_completions.rb
+++ b/features/support/step_completions.rb
@@ -65,10 +65,8 @@ module StepCompletions
   def complete_storing_step
     choose 'Just the team'
     @shared_duration = '1 year'
-    @shared_usage = 'The data will be used to create better outcomes for more children'
 
     fill_in 'How long will this information be held for?', with: @shared_duration
-    fill_in 'How will the data be used?', with: @shared_usage
     click_button 'Continue'
   end
 

--- a/features/support/step_completions.rb
+++ b/features/support/step_completions.rb
@@ -63,7 +63,7 @@ module StepCompletions
   end
 
   def complete_storing_step
-    choose 'Just the team'
+    choose 'anonymised as we process it'
     @shared_duration = '1 year'
 
     fill_in 'How long will this information be held for?', with: @shared_duration

--- a/spec/factories/research_session.rb
+++ b/spec/factories/research_session.rb
@@ -35,7 +35,6 @@ FactoryBot.define do
       status :storing
       shared_with :team
       shared_duration '1 year'
-      shared_use 'To train others'
     end
 
     trait :step_where_when do

--- a/spec/helpers/research_sessions_helper_spec.rb
+++ b/spec/helpers/research_sessions_helper_spec.rb
@@ -87,4 +87,39 @@ RSpec.describe ResearchSessionsHelper, :type => :helper do
       end
     end
   end
+
+  describe '#shared_with_lookup' do
+    let(:research_session) { double('ResearchSessionPresenter', able_to_consent?: false) }
+
+    before { assign(:research_session, research_session) }
+
+    subject { helper.shared_with_lookup(shared_with) }
+
+    context 'a static string' do
+      let(:shared_with) { :team }
+
+      it {
+        is_expected.to include(
+          'will be shared no more widely than the team undertaking the research'
+        )
+      }
+    end
+
+    context 'a consent-sensitive string' do
+      let(:shared_with) { :anonymised }
+
+      context 'not able_to_consent?' do
+        it {
+          is_expected.to include(
+            'Therefore, your child/the child in your care will not be identifiable'
+          )
+        }
+      end
+
+      context 'Actually able_to_consent?' do
+        let(:research_session) { double('ResearchSessionPresenter', able_to_consent?: true) }
+        it { is_expected.to include('Therefore, you will not be identifiable') }
+      end
+    end
+  end
 end

--- a/spec/models/research_session_spec.rb
+++ b/spec/models/research_session_spec.rb
@@ -177,16 +177,13 @@ RSpec.describe ResearchSession, type: :model do
         let(:step) { :storing }
 
         context 'no details are given' do
-          let(:set_attrs) { { shared_with: nil, shared_duration: nil, shared_use: nil } }
+          let(:set_attrs) { { shared_with: nil, shared_duration: nil } }
           it { is_expected.not_to be_valid }
           it 'has an error for shared with' do
             expect(session.errors[:shared_with].length).to eql(1)
           end
           it 'has an error for shared duration' do
             expect(session.errors[:shared_duration].length).to eql(1)
-          end
-          it 'has an error for use' do
-            expect(session.errors[:shared_use].length).to eql(1)
           end
         end
 


### PR DESCRIPTION
# [GDPR compliance for storing step](https://trello.com/c/kkuQxS8T/224-gdpr-compliance-for-our-data-now-storing-step)

> As a researcher
> I want to make sure I am choosing the right option regarding storing information
> So that the created consent form provides true info and is GPDR compliant

Add an extra `anonymised` value to `SharedWith::NAME_VALUES` and change/internationalise the text for that and all other options. Map this to finished paragraphs on the preview.

This PR supersedes #148 for the acceptance criteria related to the above, but that older PR still has changes that are not related to this card. #148 should be analysed for outstanding GDPR changes and those changes should be extracted to separate cards.

![image](https://user-images.githubusercontent.com/194511/32906308-73a9036e-caf4-11e7-9536-5bcccf446784.png)

![image](https://user-images.githubusercontent.com/194511/32906364-9855bdce-caf4-11e7-9794-d286a4d8b27e.png)


