### PR TITLE
Remove "Do I have to take part?" from info sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [FEATURE] - [Add "About taking part" to the information sheet (static)](https://trello.com/c/eth5vJYW)
 * [FEATURE] - [Add "Decide if you want the child in your care to take part" part to the info sheet (static)](https://trello.com/c/uzbzifmd/280-2-add-decide-if-you-want-the-child-in-your-care-to-take-part-part-to-the-info-sheet-static)
 * [FEATURE] - [Improve the "Where can I find out more?" section of information sheet](https://trello.com/c/VrKLhmWK/274-2-improve-the-where-can-i-find-out-more-section-of-information-sheet)
+* [FEATURE] - [Remove "Do I have to take part" from info sheet](https://trello.com/c/ZJt7BJ6n)
 
 # 0.5.0 / 2017-11-16
 

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -88,19 +88,6 @@
   %>
 
   <section>
-    <h3 class="subtitle-small" id="doi">Do I have to take part?</h3>
-    <p>
-      Taking part is entirely voluntary - it is up to you to decide whether or not <%= you_or_your_child %>
-      should take part. If you decide <%= you_or_your_child %> should take part <%= you_or_they %> do not have to answer questions <%= you_or_they %> do not want to answer. <%= you_or_they.capitalize %> can also change <%= @research_session.able_to_consent? ? 'your' : 'their' %> mind about taking part
-      at any time and withdraw without giving a reason.
-    </p>
-    <p>
-      If you agree <%= 'for your child/the child in your care' if @research_session.unable_to_consent? %> to take part, you will be given a copy of this information
-      sheet and be asked to sign a consent form.
-    </p>
-  </section>
-
-  <section>
     <h3 class="subtitle-small" id="about-taking-part">About taking part</h3>
     <p>
       <%= you_or_your_child.capitalize %> <%= @research_session.unable_to_consent? ? 'does' : 'do' %>

--- a/spec/views/research_sessions/preview.html.erb_spec.rb
+++ b/spec/views/research_sessions/preview.html.erb_spec.rb
@@ -58,11 +58,9 @@ describe 'research_sessions/preview' do
     it 'phrases blocks using "you"' do
       expect(rendered).to have_content(
         <<~TEXT
-          Taking part is entirely voluntary -
-          it is up to you to decide whether or not you should take part.
-          If you decide you should take part you do not have to answer
-          questions you do not want to answer. You can also change your mind about taking part
-          at any time and withdraw without giving a reason.
+          It is important that we test the current and future tools and services
+          that we are developing with people like you so that we can make them as
+          good as possible.
         TEXT
       )
     end
@@ -78,11 +76,9 @@ describe 'research_sessions/preview' do
     it 'phrases blocks using "your child"' do
       expect(rendered).to have_content(
         <<~TEXT
-          Taking part is entirely voluntary -
-          it is up to you to decide whether or not your child/the child in your care should take part.
-          If you decide your child/the child in your care should take part they do not have to answer
-          questions they do not want to answer. They can also change their mind about taking part
-          at any time and withdraw without giving a reason.
+          It is important that we test the current and future tools and services
+          that we are developing with people like your child/the child in your
+          care so that we can make them as good as possible.
         TEXT
       )
     end


### PR DESCRIPTION
# [Remove "Do I have to take part" from info sheet](https://trello.com/c/ZJt7BJ6n)

Removes "Do I have to take part" section. 

Changes tests which relied on "Do I have to take part copy" to test consent switch to test different copy.