### PR TITLE
Create "Session Details" section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * [FEATURE] - [Add "Decide if you want the child in your care to take part" part to the info sheet (static)](https://trello.com/c/uzbzifmd/280-2-add-decide-if-you-want-the-child-in-your-care-to-take-part-part-to-the-info-sheet-static)
 * [FEATURE] - [Improve the "Where can I find out more?" section of information sheet](https://trello.com/c/VrKLhmWK/274-2-improve-the-where-can-i-find-out-more-section-of-information-sheet)
 * [FEATURE] - [Remove "Do I have to take part" from info sheet](https://trello.com/c/ZJt7BJ6n)
+* [FEATURE] - [Update "When is the session..." content and change to "Session details"](https://trello.com/c/Xj2WfSpH/289-8-update-when-is-the-session-content-and-change-to-session-details)
+* [FEATURE] - [Merge Incentives, Expenses into "When is the session..."](https://trello.com/c/cmTxdOPX/281-2-merge-incentives-expenses-into-when-is-the-session)
 
 # 0.5.0 / 2017-11-16
 

--- a/app/helpers/research_sessions_helper.rb
+++ b/app/helpers/research_sessions_helper.rb
@@ -61,6 +61,10 @@ module ResearchSessionsHelper
     @research_session.able_to_consent? ? 'you' : 'your child/the child in your care'
   end
 
+  def your_or_your_childs
+    @research_session.able_to_consent? ? 'your' : "your child's/the child in your care's"
+  end
+
   def you_or_they
     @research_session.able_to_consent? ? 'you' : 'they'
   end

--- a/app/presenters/research_session_presenter.rb
+++ b/app/presenters/research_session_presenter.rb
@@ -70,7 +70,8 @@ class ResearchSessionPresenter
     if research_session.payment_type == 'cash'
       "a cash incentive of #{formatted_value}"
     elsif research_session.payment_type == 'voucher'
-      "high street vouchers to the value of #{formatted_value}"
+      "vouchers to the value of #{formatted_value}. "\
+      'They can be used in many high street shops'
     end
   end
 end

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -155,8 +155,8 @@
 
   <section>
     <h3 class="subtitle-small" id="concerns">
-      Decide if you want<%= 
-        ' the child in your care' if @research_session.unable_to_consent? 
+      Decide if you want<%=
+        ' the child in your care' if @research_session.unable_to_consent?
       %> to take part</h3>
 
     <p>If you are happy<%=
@@ -222,16 +222,17 @@
       <% end %>
     </section>
   <% end %>
-  <% if @research_session.incentives_enabled %>
     <section>
       <h3 class="subtitle-small">Incentives</h3>
       <p>
-        We are offering
-        <%= edit_link_for(:incentive_value) do %><%= @research_session.incentive_text %><% end %>
-        for participation in this session.
+        <%= your_or_your_childs.capitalize %> time and what <%= you_or_they %> say is really important to us.
+
+        <% if @research_session.incentives_enabled %>
+          As a thank you, we will give <%= you_or_your_child %>
+          <%= edit_link_for(:incentive_value) do %><%= @research_session.incentive_text %><% end %>.
+        <% end %>
       </p>
     </section>
-  <% end %>
 </div>
 
 <div class="print-area js-print-area" id="consent-form">

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -203,7 +203,8 @@
       </dl>
       <% if @research_session.participant_equipment.present? %>
         <p>
-          <%= edit_link_for(:participant_equipment) %>
+          <%= you_or_your_child.capitalize %> will need to bring
+          <%= edit_link_for(:participant_equipment) %>.
         </p>
       <% end %>
     <% end %>

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -181,30 +181,33 @@
     </p>
     <p>The data will be kept for <%= edit_link_for(:shared_duration) %>.</p>
   </section>
-  <% if @research_session.where_when_enabled %>
-    <section>
-      <h3 class="subtitle-small" id="private">When is the session and what should <%= @research_session.able_to_consent? ? 'I' : 'my child/the child in my care' %> bring?</h3>
-        <% if @research_session.location.present? %>
-          <p>The session will be held at <%= edit_link_for(:location) %>.</p>
+  <section>
+    <h3 class="subtitle-small" id="session-details">Session details</h3>
+    <% if @research_session.where_when_enabled %>
+      <p>The session is</p>
+      <dl class="definition-list definition-list__aligned">
+        <%
+          {
+            when_text: 'On',
+            location:  'At',
+            duration:  'Duration'
+          }.each_pair do |attr, term|
+        %>
+          <% if @research_session.send(attr).present? %>
+            <div>
+              <dt><%= term %>:</dt>
+              <dd><%= edit_link_for(attr) %></dd>
+            </div>
+          <% end  %>
         <% end %>
-        <p>
-          <% if @research_session.when_text %>
-            The session is on
-            <%= edit_link_for(:when_text) do %>
-              <strong><%= @research_session.when_text %></strong>.
-            <% end %>
-          <% end %>
-          <% if @research_session.duration.present? %>
-            The session will last for <%= edit_link_for(:duration) %>.
-          <% end %>
-        </p>
+      </dl>
       <% if @research_session.participant_equipment.present? %>
         <p>
           <%= edit_link_for(:participant_equipment) %>
         </p>
       <% end %>
-    </section>
-  <% end %>
+    <% end %>
+  </section>
   <% if @research_session.expenses_enabled %>
     <section>
       <h3 class="subtitle-small">Expenses</h3>

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -88,6 +88,58 @@
   %>
 
   <section>
+    <h3 class="subtitle-small" id="session-details">Session details</h3>
+    <% if @research_session.where_when_enabled %>
+      <p>The session is</p>
+      <dl class="definition-list">
+        <%
+          {
+            when_text: 'On',
+            location:  'At',
+            duration:  'Duration'
+          }.each_pair do |attr, term|
+        %>
+          <% if @research_session.send(attr).present? %>
+            <div>
+              <dt><%= term %>:</dt>
+              <dd><%= edit_link_for(attr) %></dd>
+            </div>
+          <% end  %>
+        <% end %>
+      </dl>
+      <p>
+        <%= your_or_your_childs.capitalize %> time and what <%= you_or_they %>
+        say is really important to us.
+
+        <% if @research_session.incentives_enabled %>
+          As a thank you, we will give <%= you_or_your_child %>
+          <%= edit_link_for(:incentive_value) do %><%= @research_session.incentive_text %><% end %>.
+        <% end %>
+      </p>
+      <% if @research_session.participant_equipment.present? %>
+        <p>
+          <%= you_or_your_child.capitalize %> will need to bring
+          <%= edit_link_for(:participant_equipment) %>.
+        </p>
+      <% end %>
+    <% end %>
+    <% if @research_session.expenses_enabled %>
+      <p>
+        <%= edit_link_for(:travel_expenses_limit) do %>
+          <%= @research_session.expenses_sentence %>
+        <% end %>
+      </p>
+      <% if @research_session.receipts_required %>
+        <p>
+          <%= edit_link_for(:receipts_required) do %>
+            Receipts must be provided.
+          <% end %>
+        </p>
+      <% end %>
+    <% end %>
+  </section>
+
+  <section>
     <h3 class="subtitle-small" id="about-taking-part">About taking part</h3>
     <p>
       <%= you_or_your_child.capitalize %> <%= @research_session.unable_to_consent? ? 'does' : 'do' %>
@@ -181,62 +233,6 @@
     </p>
     <p>The data will be kept for <%= edit_link_for(:shared_duration) %>.</p>
   </section>
-  <section>
-    <h3 class="subtitle-small" id="session-details">Session details</h3>
-    <% if @research_session.where_when_enabled %>
-      <p>The session is</p>
-      <dl class="definition-list definition-list__aligned">
-        <%
-          {
-            when_text: 'On',
-            location:  'At',
-            duration:  'Duration'
-          }.each_pair do |attr, term|
-        %>
-          <% if @research_session.send(attr).present? %>
-            <div>
-              <dt><%= term %>:</dt>
-              <dd><%= edit_link_for(attr) %></dd>
-            </div>
-          <% end  %>
-        <% end %>
-      </dl>
-      <% if @research_session.participant_equipment.present? %>
-        <p>
-          <%= you_or_your_child.capitalize %> will need to bring
-          <%= edit_link_for(:participant_equipment) %>.
-        </p>
-      <% end %>
-    <% end %>
-  </section>
-  <% if @research_session.expenses_enabled %>
-    <section>
-      <h3 class="subtitle-small">Expenses</h3>
-      <p>
-        <%= edit_link_for(:travel_expenses_limit) do %>
-          <%= @research_session.expenses_sentence %>
-        <% end %>
-      </p>
-      <% if @research_session.receipts_required %>
-        <p>
-          <%= edit_link_for(:receipts_required) do %>
-            Receipts must be provided.
-          <% end %>
-        </p>
-      <% end %>
-    </section>
-  <% end %>
-    <section>
-      <h3 class="subtitle-small">Incentives</h3>
-      <p>
-        <%= your_or_your_childs.capitalize %> time and what <%= you_or_they %> say is really important to us.
-
-        <% if @research_session.incentives_enabled %>
-          As a thank you, we will give <%= you_or_your_child %>
-          <%= edit_link_for(:incentive_value) do %><%= @research_session.incentive_text %><% end %>.
-        <% end %>
-      </p>
-    </section>
 </div>
 
 <div class="print-area js-print-area" id="consent-form">

--- a/features/support/preview_checker.rb
+++ b/features/support/preview_checker.rb
@@ -42,7 +42,6 @@ module PreviewChecker
   end
 
   def check_where_when
-    expect(page.body).to include('The session is on')
     expect(page).to have_tag('a.editable', text: @session_duration)
     expect(page).to have_tag('a.editable', text: @session_location)
     expect(page).to have_tag('a.editable', text: @held_on)

--- a/features/support/preview_checker.rb
+++ b/features/support/preview_checker.rb
@@ -60,9 +60,8 @@ module PreviewChecker
   end
 
   def check_incentives
-    expect(page.body).to include('We are offering')
+    expect(page.body).to include('As a thank you, we will give your child')
     expect(page).to have_tag('a.editable', text: 'a cash incentive of £10.50')
-    expect(page.body).to include('for participation in this session')
   end
 end
 

--- a/spec/presenters/research_session_presenter_spec.rb
+++ b/spec/presenters/research_session_presenter_spec.rb
@@ -180,7 +180,8 @@ RSpec.describe ResearchSessionPresenter do
       end
       it 'has a message about the high street voucher value' do
         expect(text).to eql(
-          "high street vouchers to the value of £#{formatted_value}"
+          "vouchers to the value of £#{formatted_value}. "\
+          'They can be used in many high street shops'
         )
       end
     end

--- a/spec/views/research_sessions/preview.html.erb_spec.rb
+++ b/spec/views/research_sessions/preview.html.erb_spec.rb
@@ -36,7 +36,7 @@ describe 'research_sessions/preview' do
     end
 
     it 'shows the duration' do
-      expect(rendered).to match(/The session will last for.*Three minutes/m)
+      expect(rendered).to match(/Duration.*Three minutes/m)
     end
   end
 
@@ -44,11 +44,11 @@ describe 'research_sessions/preview' do
     let(:extra_attrs) { { when_text: '27th September 2017', duration: nil } }
 
     it 'shows the date and time' do
-      expect(rendered).to match(/The session is on.*27th September 2017/m)
+      expect(rendered).to match(/On.*27th September 2017/m)
     end
 
     it 'does not show the duration' do
-      expect(rendered).not_to match(/The session will last for/m)
+      expect(rendered).not_to have_content('Duration')
     end
   end
 


### PR DESCRIPTION
# Create 'session details' section from the content in other areas

> As a research participant
> I want my Information Sheet to be as simple as possible
> So that I can understand what I am consenting to

This PR combines two related cards:

## [1. Update "When is the session..." content and change to "Session details"](https://trello.com/c/Xj2WfSpH/289-8-update-when-is-the-session-content-and-change-to-session-details)
## [2. Merge Incentives, Expenses into "When is the session..."](https://trello.com/c/cmTxdOPX/281-2-merge-incentives-expenses-into-when-is-the-session)

![image](https://user-images.githubusercontent.com/194511/33668810-adbec724-da98-11e7-9768-fe2232968f9b.png)
