### PR TITLE
Order preview headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [FEATURE] - [Remove "Do I have to take part" from info sheet](https://trello.com/c/ZJt7BJ6n)
 * [FEATURE] - [Update "When is the session..." content and change to "Session details"](https://trello.com/c/Xj2WfSpH/289-8-update-when-is-the-session-content-and-change-to-session-details)
 * [FEATURE] - [Merge Incentives, Expenses into "When is the session..."](https://trello.com/c/cmTxdOPX/281-2-merge-incentives-expenses-into-when-is-the-session)
+* [FEATURE] - [Review the headers/section order of the information sheet](https://trello.com/c/VIAe530f/272-1-review-the-headers-section-order-of-the-information-sheet)
 
 # 0.5.0 / 2017-11-16
 

--- a/app/helpers/research_sessions_helper.rb
+++ b/app/helpers/research_sessions_helper.rb
@@ -68,4 +68,12 @@ module ResearchSessionsHelper
   def you_or_they
     @research_session.able_to_consent? ? 'you' : 'they'
   end
+
+  def i_or_they
+    @research_session.able_to_consent? ? 'I' : 'they'
+  end
+
+  def say_or_says
+    @research_session.able_to_consent? ? 'say' : 'says'
+  end
 end

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -167,17 +167,6 @@
   </section>
 
   <section>
-    <h3 class="subtitle-small" id="private">Will what I say be kept confidential?</h3>
-    <p>Yes. The goal of design research isnʼt to collect data, itʼs to find the
-      insights we need to improve our services. We do not hand over the recordings; we
-      edit and share insights relevant to the project. Whenever we share these
-      insights, the material is fully anonymised and contributions cannot be
-      attributed to named individuals.</p>
-    <p><%= you_or_your_child.capitalize %> will not be identifiable in anything published. All personal data
-      collected as part of the research is stored securely and kept strictly
-      confidential.</p>
-  </section>
-  <section>
     <h3 class="subtitle-small" id="sharing-information">Sharing information</h3>
     <p>
       We may have to share information about <%= you_or_your_child %> without

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -140,25 +140,6 @@
   </section>
 
   <section>
-    <h3 class="subtitle-small" id="about-taking-part">About taking part</h3>
-    <p>
-      <%= you_or_your_child.capitalize %> <%= @research_session.unable_to_consent? ? 'does' : 'do' %>
-      not have to take part in this session. It is your decision<%= ' as the parent/carer' if @research_session.unable_to_consent? %>.
-    </p>
-    <p>
-      We will also ask <%= you_or_your_child %> if <%= you_or_they %> want to take
-      part before the session.
-    </p>
-    <p>
-      Don’t worry! If you do not want <%= 'the child in your care' if @research_session.unable_to_consent? %>
-      to take part it will not affect the service <%= you_or_they %> may receive.
-    </p>
-    <p>
-      <%= you_or_they.capitalize %> can change your mind at any point for any
-      reason - just let us know!
-    </p>
-  </section>
-  <section>
     <h3 class="subtitle-small" id="private">Will what I say be kept confidential?</h3>
     <p>Yes. The goal of design research isnʼt to collect data, itʼs to find the
       insights we need to improve our services. We do not hand over the recordings; we
@@ -192,6 +173,26 @@
       your consent if we think <%= you_or_they %> or someone else is at risk
       of serious harm. Where possible, the lead researcher speak to you first
       and ask you what you want to do about the situation.
+    </p>
+  </section>
+
+  <section>
+    <h3 class="subtitle-small" id="about-taking-part">About taking part</h3>
+    <p>
+      <%= you_or_your_child.capitalize %> <%= @research_session.unable_to_consent? ? 'does' : 'do' %>
+      not have to take part in this session. It is your decision<%= ' as the parent/carer' if @research_session.unable_to_consent? %>.
+    </p>
+    <p>
+      We will also ask <%= you_or_your_child %> if <%= you_or_they %> want to take
+      part before the session.
+    </p>
+    <p>
+      Don’t worry! If you do not want <%= 'the child in your care' if @research_session.unable_to_consent? %>
+      to take part it will not affect the service <%= you_or_they %> may receive.
+    </p>
+    <p>
+      <%= you_or_they.capitalize %> can change your mind at any point for any
+      reason - just let us know!
     </p>
   </section>
 

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -188,7 +188,7 @@
     </p>
     <p>
       Don’t worry! If you do not want <%= 'the child in your care' if @research_session.unable_to_consent? %>
-      to take part it will not affect the service <%= you_or_they %> may receive.
+      to take part it will not affect the service <%= you_or_they %> receive.
     </p>
     <p>
       <%= you_or_they.capitalize %> can change your mind at any point for any

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -140,6 +140,33 @@
   </section>
 
   <section>
+    <h3 class="subtitle-small" id="confidential">
+      Will anyone know what <%= i_or_they %> say in the discussion?
+    </h3>
+
+    <p>
+      The only people who will hear what <%= you_or_your_child %> <%= say_or_says %> in the session
+      will be the researchers running the session, other young people taking part, and
+      service workers facilitating the session.
+    </p>
+
+    <p>
+      <%= edit_link_for(:shared_with) do %>
+        <%= shared_with_lookup(@research_session.shared_with) %>
+      <% end %>
+    </p>
+
+    <p>
+      Barnardo’s will hold research data for <%= edit_link_for(:shared_duration) %>
+      after the closure of this project, after which it will be deleted.
+      Personal data is stored in a safe and secure way.
+    </p>
+    <p>
+      You can contact Jason Caplin to ask us to delete your personal data at any time.
+    </p>
+  </section>
+
+  <section>
     <h3 class="subtitle-small" id="private">Will what I say be kept confidential?</h3>
     <p>Yes. The goal of design research isnʼt to collect data, itʼs to find the
       insights we need to improve our services. We do not hand over the recordings; we
@@ -225,15 +252,6 @@
     </ol>
 
     <p>Thank you!</p>
-  </section>
-  <section>
-    <h3 class="subtitle-small" id="private">How will the data be used?</h3>
-    <p>
-      <%= edit_link_for(:shared_with) do %>
-        <%= shared_with_lookup(@research_session.shared_with) %>
-      <% end %>
-    </p>
-    <p>The data will be kept for <%= edit_link_for(:shared_duration) %>.</p>
   </section>
 </div>
 

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -207,7 +207,7 @@
   %>
 
   <section>
-    <h3 class="subtitle-small" id="concerns">
+    <h3 class="subtitle-small" id="decide">
       Decide if you want<%=
         ' the child in your care' if @research_session.unable_to_consent?
       %> to take part</h3>

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -30,7 +30,7 @@
   </section>
 
   <section>
-    <h3 class="subtitle-small" id="why">Why is the research being done?</h3>
+    <h3 class="subtitle-small" id="why">Why we are doing research</h3>
 
     <p>
       <%= I18n.t('research_session_attr_labels.topic') %>

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -151,22 +151,6 @@
       confidential.</p>
   </section>
   <section>
-    <h3 class="subtitle-small" id="concerns">Concerns and complaints</h3>
-
-    <p>If you have any concerns or a complaint, or would like to have your data deleted please contact:
-
-    <dl class="definition-list">
-      <div>
-        <dt class="definition-list__term">Telephone:</dt>
-        <dd>+442084987869</dd>
-      </div>
-      <div>
-        <dt class="definition-list__term">Email:</dt>
-        <dd><%= mail_to 'jason.caplin@barnardos.org.uk' %></dd>
-      </div>
-    </dl>
-  </section>
-  <section>
     <h3 class="subtitle-small" id="sharing-information">Sharing information</h3>
     <p>
       We may have to share information about <%= you_or_your_child %> without
@@ -205,6 +189,23 @@
       }
     )
   %>
+
+  <section>
+    <h3 class="subtitle-small" id="concerns">Concerns and complaints</h3>
+
+    <p>If you have any concerns or a complaint, or would like to have your data deleted please contact:
+
+    <dl class="definition-list">
+      <div>
+        <dt class="definition-list__term">Telephone:</dt>
+        <dd>+442084987869</dd>
+      </div>
+      <div>
+        <dt class="definition-list__term">Email:</dt>
+        <dd><%= mail_to 'jason.caplin@barnardos.org.uk' %></dd>
+      </div>
+    </dl>
+  </section>
 
   <section>
     <h3 class="subtitle-small" id="decide">

--- a/features/support/preview_checker.rb
+++ b/features/support/preview_checker.rb
@@ -35,7 +35,7 @@ module PreviewChecker
   end
 
   def check_storing
-    expect(page).to have_tag('p', text: "The data will be kept for #{@shared_duration}.")
+    expect(page).to have_content("Barnardo’s will hold research data for #{@shared_duration}")
     expect(page).to have_content(
       'Any research recordings will have names and personal details removed and replaced'
     )


### PR DESCRIPTION
# [Review the headers/section order of the information sheet](https://trello.com/c/VIAe530f/272-1-review-the-headers-section-order-of-the-information-sheet)

We re-ordered the last bits of the page according to the [document](https://docs.google.com/document/d/1j8HWIUxYyquEZb9RpnZYBVX1SFtwEYg7TqRA3lfO9bI/edit).

We also found that there was no card for:

- Moving preview "storing" section to "confidentiality"
- Remove "Will what I say be kept confidential?"
- Removing extraneous "may" from "About taking part"
- Renaming incorrect "concerns" id to "decide"

Rather than open new cards we've just mopped those up here.