### PR TITLE
Update 'consent form' heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [FEATURE] - [Update "When is the session..." content and change to "Session details"](https://trello.com/c/Xj2WfSpH/289-8-update-when-is-the-session-content-and-change-to-session-details)
 * [FEATURE] - [Merge Incentives, Expenses into "When is the session..."](https://trello.com/c/cmTxdOPX/281-2-merge-incentives-expenses-into-when-is-the-session)
 * [FEATURE] - [Review the headers/section order of the information sheet](https://trello.com/c/VIAe530f/272-1-review-the-headers-section-order-of-the-information-sheet)
+* [BUG] - [Change 'review' consent form heading to 'Consent form'](https://trello.com/c/2Hjw3duY/294-change-review-consent-form-heading-to-consent-form)
 
 # 0.5.0 / 2017-11-16
 

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -252,7 +252,7 @@
 </div>
 
 <div class="print-area js-print-area" id="consent-form">
-  <h2 class="heading-large">Review</h2>
+  <h2 class="heading-large">Consent form</h2>
 
   <p class="super-text">It is important to us that your consent
     <%= 'for your child' if @research_session.unable_to_consent? %> to


### PR DESCRIPTION
The heading is 'Review' which gives no context of the consent form it is
titling.

Update the copy to relate to the consent form.