### PR TITLE
Apply design rules featured in the original Barnardo's styleguide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [FEATURE] - [Live preview: Topic / Purpose](https://trello.com/c/JiSAAKBv/256-3-live-preview-topic-purpose)
 * [BUG] - [Researcher preview phone number/word missing](https://trello.com/c/Vt4JdtH5/293-bugs-researcher-preview)
 * [BUG] - [Live previews broken in every live environment](https://trello.com/c/BV2jgy9O/295-live-previews-broken-in-every-live-environment)
+* [BUG] - [Apply design rules featured in the original Barnardo's styleguide](https://trello.com/c/CtYloVeU/286-apply-design-rules-featured-in-the-original-barnardos-styleguide)
 
 # 0.5.0 / 2017-11-16
 

--- a/app/assets/stylesheets/app/consent_form_preview.scss
+++ b/app/assets/stylesheets/app/consent_form_preview.scss
@@ -7,18 +7,17 @@
 
 .writing-field {
   display: inline-block;
-  margin-bottom: 24px;
+  margin-top: 32px;
   padding-right: $gutter;
 
   label {
     display: block;
-    margin-bottom: $gutter * 1.5;
-    margin-top: $gutter;
   }
 
   .space-for-writing {
     border: 0;
     border-bottom: 1px solid $black;
+    margin-top: 32px;
     width: 100%;
   }
 

--- a/app/assets/stylesheets/app/session_preview.scss
+++ b/app/assets/stylesheets/app/session_preview.scss
@@ -1,10 +1,4 @@
 .editable {
-  display: inline-block;
   background: $highlight-background-colour;
   padding: .2em;
-
-  // TODO: Remove `> p` when topic and purpose are no longer useing `simple_format`
-  > p {
-    margin: 0;
-  }
 }

--- a/app/assets/stylesheets/barnardos/_lists.scss
+++ b/app/assets/stylesheets/barnardos/_lists.scss
@@ -1,30 +1,38 @@
 .bullet-point-list {
   list-style-type: disc;
-  margin: 0 $gutter;
+  margin: 16px 0 0 16px;
+  padding-left: $gutter;
 
   > * {
-    margin: $gutter;
+    font-size: 18px;
     line-height: 24px;
+    margin-top: 8px;
   }
 }
 
 .numbered-list {
   list-style-type: decimal;
-  margin: 0 $gutter;
+  margin: 16px 0 0 16px;
+  padding-left: $gutter;
 
   > * {
-    margin: $gutter;
+    font-size: 18px;
     line-height: 24px;
+    margin-top: 8px;
   }
 }
 
 .definition-list {
-  div {
-    line-height: 24px;
+  margin-top: 16px;
 
-    dt,
-    dd {
-      display: inline;
-    }
+  div {
+    margin-top: 8px;
+  }
+
+  dt,
+  dd {
+    display: inline;
+    font-size: 18px;
+    line-height: 24px;
   }
 }

--- a/app/assets/stylesheets/barnardos/_page.scss
+++ b/app/assets/stylesheets/barnardos/_page.scss
@@ -60,6 +60,6 @@
 }
 
 #content {
-  margin: 0 auto 0 0;
+  margin: 0 auto 0 auto;
   max-width: $max-content-width;
 }

--- a/app/assets/stylesheets/barnardos/_print-section.scss
+++ b/app/assets/stylesheets/barnardos/_print-section.scss
@@ -9,8 +9,8 @@
 
   &__select {
     font-size: 1rem;
-    margin-bottom: $gutter;
     width: 100%;
+    display: block;
 
     @media (min-width: $tablet) {
       width: auto;
@@ -23,11 +23,11 @@
     background-position: right $gutter center;
     background-size: 22px 22px;
     padding: $gutter (22px + $gutter * 2);
-    margin: 0;
+    margin: 16px 0 0 0;
 
     @media (min-width: $tablet) {
       padding-left: $gutter;
-      margin-left: $gutter;
+      margin: 0 0 0 16px;
     }
 
     &:hover {

--- a/app/assets/stylesheets/barnardos/_progress.scss
+++ b/app/assets/stylesheets/barnardos/_progress.scss
@@ -5,10 +5,10 @@ $progress-indicator-color-active: #e2f2ce;
 
 .progress {
   margin: ($gutter * 2) ($gutter / 2) ($gutter * 4);
-  max-width: $max-content-width;
+  max-width: $max-container-width;
 
   @media (min-width: $tablet) {
-    margin: ($gutter * 2) 0;
+    margin: ($gutter * 2) auto;
     padding-bottom: $gutter * 3;
     padding-left: 30px;
   }

--- a/app/assets/stylesheets/barnardos/_reactive-container.scss
+++ b/app/assets/stylesheets/barnardos/_reactive-container.scss
@@ -3,7 +3,7 @@
 }
 
 .reactive-container__form {
-  flex: 2;
+  flex: 1;
 }
 
 .reactive-container__preview {

--- a/app/assets/stylesheets/barnardos/_reactive-preview.scss
+++ b/app/assets/stylesheets/barnardos/_reactive-preview.scss
@@ -7,11 +7,17 @@ $preview-highlight-background-colour: #ffe4b5;
 
 .reactive-preview__section {
   background: $preview-section-background-colour;
-  padding: 8px 16px;
+  padding: 16px;
 }
 
 .reactive-preview__section:not(:first-child) {
   margin-top: 8px;
+}
+
+.reactive-preview__heading {
+  font-size: 23px;
+  line-height: 28px;
+  margin-top: 0;
 }
 
 .reactive-preview__highlight {

--- a/app/assets/stylesheets/barnardos/_split-link.scss
+++ b/app/assets/stylesheets/barnardos/_split-link.scss
@@ -2,13 +2,14 @@
 @import "barnardos/vars";
 
 .split-link {
+  margin-top: 32px;
   display: block;
 
   > * {
     background: $grey-medium;
     border-radius: 4px;
     display: block;
-    margin: $gutter 0;
+    margin: $gutter 0 0 0;
     padding: $gutter $gutter * 4;
     text-align: center;
     text-decoration: none;

--- a/app/assets/stylesheets/barnardos/_type.scss
+++ b/app/assets/stylesheets/barnardos/_type.scss
@@ -15,91 +15,47 @@
   src: font-url("pnalt-medium.otf") format("opentype");
 }
 
-.title {
+h1 {
+  font-size: 52px;
+  font-weight: bold;
+  line-height: 56px;
+  margin: 48px 0 0 0;
+}
+
+h2 {
   font-size: 36px;
   font-weight: bold;
-  line-height: 36px;
-  margin: 16px 0;
-
-  @media (min-width: $tablet) {
-    font-size: 52px;
-    line-height: 56px;
-    margin: 32px 0;
-  }
+  line-height: 48px;
+  margin: 32px 0 0 0;
 }
 
-h2,
-.subtitle-large {
+h3 {
   font-size: 29px;
-  font-weight: normal;
-  line-height: 32px;
-  margin: 12px 0;
-
-  @media (min-width: $tablet) {
-    font-size: 36px;
-    line-height: 48px;
-    margin: 16px 0;
-  }
+  font-weight: bold;
+  line-height: 42px;
+  margin: 32px 0 0 0;
+  color: $black;
 }
 
-h3,
-.subtitle-medium {
+.super-text {
   font-size: 23px;
-  font-weight: normal;
-  line-height: 24px;
-  margin: 16px 0;
-  color: $black;
-
-  @media (min-width: $tablet) {
-    font-size: 29px;
-    line-height: 42px;
-    color: $black;
-  }
+  line-height: 36px;
+  margin: 16px 0 0 0;
 }
 
-h4,
-.subtitle-small {
-  font-size: 18px;
-  font-weight: normal;
-  line-height: 24px;
-  margin: 16px 0;
-  color: $black;
-
-  @media (min-width: $tablet) {
-    font-size: 23px;
-    line-height: 28px;
-    color: $black;
-  }
-}
-
-.shorter-text,
-p,
-p.short-text {
-
-  font-size: 16px;
-  line-height: 16px;
-  margin: 24px 0;
-
-  @media (min-width: $tablet) {
-    font-size: 18px;
-    line-height: 24px;
-    margin: 32px 0;
-  }
-}
-
-.super-text,
-p.super-text {
+p {
   font-size: 18px;
   line-height: 24px;
-  margin: 24px 0;
-
-  @media (min-width: $tablet) {
-    font-size: 23px;
-    line-height: 36px;
-    margin: 32px 0;
-  }
+  margin: 16px 0 0 0;
 }
 
 .nowrap {
   white-space: nowrap;
+}
+
+.page-heading {
+  font-size: 52px;
+  font-weight: bold;
+  line-height: 56px;
+  margin: 48px 0 0 0;
 }

--- a/app/assets/stylesheets/barnardos/_vars.scss
+++ b/app/assets/stylesheets/barnardos/_vars.scss
@@ -3,7 +3,7 @@ $desktop: 958px;
 $page-width: 1280px;
 $gutter: 16px;
 $max-container-width: $page-width - (2 * $gutter);
-$max-content-width: 50em;
+$max-content-width: 42em;
 $max-form-control-width: 35em;
 $col: 89px;
 $font-family: ProximaNova;

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -18,3 +18,8 @@ p {
   page-break-inside: avoid;
 }
 
+.editable,
+.definition-list a {
+  color: inherit;
+  text-decoration: none;
+}

--- a/app/javascript/components/Shared/FindOutMore.js
+++ b/app/javascript/components/Shared/FindOutMore.js
@@ -14,7 +14,7 @@ const FindOutMore = (props) => {
 
   return (
     <section className={ props.finalPreview ? '' : 'reactive-preview__section' }>
-      <h3 className="subtitle-small" id="more">Find out more</h3>
+      <h3 className={ props.finalPreview ? '' : 'reactive-preview__heading' } id="more">Find out more</h3>
       <p>If you have any questions about the research please contact {Output(props, 'researcher_name')}:</p>
       <dl className="definition-list">
         <div>

--- a/app/javascript/components/Shared/WhatHappensInThisResearchSession.js
+++ b/app/javascript/components/Shared/WhatHappensInThisResearchSession.js
@@ -12,11 +12,12 @@ const WhatHappensInThisResearchSession = (props) => {
 
   return (
     <section className={ props.finalPreview ? '' : 'reactive-preview__section' }>
-      <h3 className="subtitle-small" id="what">What happens in this research session?</h3>
-
-      {Output(props, 'researcher_name')}
-      {jobTitle} would like {props.you_or_your_child} to take part in
-      {colonOrEllipsis}
+      <h3 className={ props.finalPreview ? '' : 'reactive-preview__heading' } id="what">What happens in this research session?</h3>
+      <p>
+        {Output(props, 'researcher_name')}
+        {jobTitle} would like {props.you_or_your_child} to take part in
+        {colonOrEllipsis}
+      </p>
 
       <div dangerouslySetInnerHTML={{__html: props.methodologies_markup}} />
       <div dangerouslySetInnerHTML={{__html: props.recording_markup}} />

--- a/app/javascript/components/TopicPurposePreviews/index.js
+++ b/app/javascript/components/TopicPurposePreviews/index.js
@@ -11,8 +11,7 @@ class TopicPurposePreviews extends PreviewBase {
   render () {
     return (
       <div>
-        <h3 className="subtitle-small" id="why">Why we are doing research</h3>
-
+        <h3 className={ this.props.finalPreview ? '' : 'reactive-preview__heading' } id="why">Why we are doing research</h3>
         <p>
           {this.props.labels.topic}
           {' '}{Output(this.state, 'topic')}{' '}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,7 +32,7 @@
 </header>
 
 <nav class="global-header-bar">
-  <ul class="research-session-commands">
+  <ul class="research-session-commands screen-only">
     <% unless already_creating_session? %>
       <li class="research-session-commands__item">
         <%=

--- a/app/views/research_sessions/new.html.erb
+++ b/app/views/research_sessions/new.html.erb
@@ -1,5 +1,5 @@
 <div class="main-content">
-  <h1 class="title">Create tailored consent and information forms </h1>
+  <h1 class="page-heading">Create tailored consent and information forms </h1>
   <p class="super-text">
     This tool will guide you through a series of questions. Your answers
     will help generate tailored information sheets and consent forms

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -11,7 +11,7 @@
   <button type="submit" class="print-section__submit button">Print</button>
 </form>
 
-<h1 class="title screen-only">Research session preview</h1>
+<h1 class="page-heading screen-only">Research session preview</h1>
 
 <section class="split-link screen-only">
   <div class="<%='active' if @research_session.able_to_consent? %>">
@@ -24,7 +24,7 @@
 
 <div class="print-area js-print-area" id="info-sheets">
   <section>
-    <h2 class="heading-medium">About this research project</h2>
+    <h2>About this research project</h2>
     <p class="super-text">This information sheet will tell you more about the
       research so that you can decide whether or not <%= you_or_your_child %> would like to take part.</p>
   </section>
@@ -64,18 +64,16 @@
   <% end %>
 
   <% recording = capture do %>
-    <p>
-      Which we will record using:
-      <ul class="bullet-point-list">
-        <% @research_session.recording_methods.each do |recording_method| %>
-          <li>
-            <%= edit_link_for(:recording_methods) do %>
-              <%= recording_method_lookup(recording_method) %>
-            <% end %>
-          </li>
-        <% end %>
-      </ul>
-    </p>
+    <p>Which we will record using:</p>
+    <ul class="bullet-point-list">
+      <% @research_session.recording_methods.each do |recording_method| %>
+        <li>
+          <%= edit_link_for(:recording_methods) do %>
+            <%= recording_method_lookup(recording_method) %>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
   <% end %>
 
   <%=
@@ -96,7 +94,7 @@
         @research_session.where_when_enabled ||
         @research_session.expenses_enabled %>
     <section>
-      <h3 class="subtitle-small" id="session-details">Session details</h3>
+      <h3 id="session-details">Session details</h3>
       <% if @research_session.where_when_enabled %>
         <dl class="definition-list">
           <%
@@ -152,7 +150,7 @@
   <% end %>
 
   <section>
-    <h3 class="subtitle-small" id="confidential">
+    <h3 id="confidential">
       Will anyone know what <%= i_or_they %> say in the discussion?
     </h3>
 
@@ -179,7 +177,7 @@
   </section>
 
   <section>
-    <h3 class="subtitle-small" id="sharing-information">Sharing information</h3>
+    <h3 id="sharing-information">Sharing information</h3>
     <p>
       We may have to share information about <%= you_or_your_child %> without
       your consent if we think <%= you_or_they %> or someone else is at risk
@@ -189,7 +187,7 @@
   </section>
 
   <section>
-    <h3 class="subtitle-small" id="about-taking-part">About taking part</h3>
+    <h3 id="about-taking-part">About taking part</h3>
     <p>
       <%= you_or_your_child.capitalize %> <%= @research_session.unable_to_consent? ? 'does' : 'do' %>
       not have to take part in this session. It is your decision<%= ' as the parent/carer' if @research_session.unable_to_consent? %>.
@@ -216,7 +214,7 @@
   %>
 
   <section>
-    <h3 class="subtitle-small" id="concerns">Concerns and complaints</h3>
+    <h3 id="concerns">Concerns and complaints</h3>
 
     <p>If you have any concerns or a complaint, or would like to have your data deleted please contact:
 
@@ -233,7 +231,7 @@
   </section>
 
   <section>
-    <h3 class="subtitle-small" id="decide">
+    <h3 id="decide">
       Decide if you want<%=
         ' the child in your care' if @research_session.unable_to_consent?
       %> to take part</h3>
@@ -254,9 +252,9 @@
 </div>
 
 <div class="print-area js-print-area" id="consent-form">
-  <h2 class="heading-large">Consent form</h2>
+  <h2 class="page-heading">Consent form</h2>
 
-  <p class="super-text">It is important to us that your consent
+  <p>It is important to us that your consent
     <%= 'for your child' if @research_session.unable_to_consent? %> to
     take part in this research is freely given and fully informed.</p>
   <p>Please review the following points and indicate your agreement to the
@@ -281,7 +279,7 @@
     </li>
   </ul>
 
-  <p class="highlight super-text">
+  <p>
     I agree to my <%= 'childʼs' if @research_session.unable_to_consent? %>
     participation in this research and understand that
     my childʼs data will be used as explained above.

--- a/app/views/research_sessions/questions/expenses.html.erb
+++ b/app/views/research_sessions/questions/expenses.html.erb
@@ -1,7 +1,7 @@
 <%= render "research_sessions/progress" %>
 <div class="main-content">
   <%= render 'shared/error_summary' %>
-  <h1 class="subtitle-large">Expenses</h1>
+  <h1 class="page-heading">Expenses</h1>
   <%= barnardos_form_with model: @research_session, url: wizard_path do |form| %>
 
     <%= form.radio_group_vertical :expenses_enabled,

--- a/app/views/research_sessions/questions/incentives.html.erb
+++ b/app/views/research_sessions/questions/incentives.html.erb
@@ -1,7 +1,7 @@
 <%= render "research_sessions/progress" %>
 <div class="main-content">
   <%= render 'shared/error_summary' %>
-  <h1 class="subtitle-large">Incentives</h1>
+  <h1 class="page-heading">Incentives</h1>
   <%= barnardos_form_with model: @research_session, url: wizard_path do |form| %>
       <%= form.radio_group_vertical :incentives_enabled,
           { true => 'Yes', false => 'No' },

--- a/app/views/research_sessions/questions/methodologies.html.erb
+++ b/app/views/research_sessions/questions/methodologies.html.erb
@@ -1,7 +1,7 @@
 <%= render "research_sessions/progress" %>
 <div class="main-content">
   <%= render 'shared/error_summary' %>
-  <h1 class="subtitle-large">Methodologies</h1>
+  <h1 class="page-heading">Methodologies</h1>
   <%= barnardos_form_with model: @research_session, url: wizard_path do |form| %>
       <%= form.checkbox_group_vertical(
             :methodologies,

--- a/app/views/research_sessions/questions/recording.html.erb
+++ b/app/views/research_sessions/questions/recording.html.erb
@@ -1,7 +1,7 @@
 <%= render "research_sessions/progress" %>
 <div class="main-content">
   <%= render 'shared/error_summary' %>
-  <h1 class="subtitle-large">Recording</h1>
+  <h1 class="page-heading">Recording</h1>
   <%= barnardos_form_with model: @research_session, url: wizard_path do |form| %>
       <%= form.checkbox_group_vertical(
             :recording_methods,

--- a/app/views/research_sessions/questions/researcher.html.erb
+++ b/app/views/research_sessions/questions/researcher.html.erb
@@ -1,7 +1,7 @@
 <%= render "research_sessions/progress" %>
 <div class="main-content">
   <%= render 'shared/error_summary' %>
-  <h1 class="subtitle-large">Researcher</h1>
+  <h1 class="page-heading">Researcher</h1>
   <%= barnardos_form_with model: @research_session, url: wizard_path do |form| %>
 
       <fieldset class="fieldset">

--- a/app/views/research_sessions/questions/storing.html.erb
+++ b/app/views/research_sessions/questions/storing.html.erb
@@ -1,7 +1,7 @@
 <%= render "research_sessions/progress" %>
 <div class="main-content">
   <%= render 'shared/error_summary' %>
-  <h1 class="subtitle-large">Storing</h1>
+  <h1 class="page-heading">Storing</h1>
   <%= barnardos_form_with model: @research_session, url: wizard_path do |form| %>
 
     <%= form.radio_group_vertical \

--- a/app/views/research_sessions/questions/topic.html.erb
+++ b/app/views/research_sessions/questions/topic.html.erb
@@ -1,7 +1,7 @@
 <%= render "research_sessions/progress" %>
 <div class="main-content">
   <%= render 'shared/error_summary' %>
-  <h1 class="subtitle-large">Topic</h1>
+  <h1 class="page-heading">Topic</h1>
   <%= barnardos_form_with model: @research_session, url: wizard_path do |form| %>
     <div class="reactive-container">
       <div class="reactive-container__form">

--- a/app/views/research_sessions/questions/where_when.html.erb
+++ b/app/views/research_sessions/questions/where_when.html.erb
@@ -1,7 +1,7 @@
 <%= render "research_sessions/progress" %>
 <div class="main-content">
   <%= render 'shared/error_summary' %>
-  <h1 class="subtitle-large">Where &amp; when</h1>
+  <h1 class="page-heading">Where &amp; when</h1>
   <%= barnardos_form_with model: @research_session, url: wizard_path do |form| %>
 
     <%= form.radio_group_vertical :where_when_enabled,


### PR DESCRIPTION
# [Apply design rules featured in the original Barnardo's styleguide](https://trello.com/c/CtYloVeU/286-apply-design-rules-featured-in-the-original-barnardos-styleguide)

- Apply font sizes to copy / headings from the Barnardo's styleguide
- Elements should use `margin-top` to create flow for content
- Reduce width of content to make the lines shorter therefore easier to read
- Ensure print styles make the final outcome look like a document rather than a website

![screenshot-2017-12-12 preview print research](https://user-images.githubusercontent.com/893208/33876624-efce8ac6-df1d-11e7-8347-698a26f2239a.png)
