### PR TITLE
WIP! Test ResearcherPreviews constructor name hypothesis

### DIFF
--- a/app/javascript/components/ResearcherPreviews/index.js
+++ b/app/javascript/components/ResearcherPreviews/index.js
@@ -5,10 +5,6 @@ import FindOutMore from '../Shared/FindOutMore'
 import WhatHappensInThisResearchSession from '../Shared/WhatHappensInThisResearchSession'
 
 class ResearcherPreviews extends PreviewBase {
-  componentName () {
-    return 'ResearcherPreviews'
-  }
-
   render () {
     return (
       <div>

--- a/app/javascript/components/ResearcherPreviews/index.js
+++ b/app/javascript/components/ResearcherPreviews/index.js
@@ -5,6 +5,10 @@ import FindOutMore from '../Shared/FindOutMore'
 import WhatHappensInThisResearchSession from '../Shared/WhatHappensInThisResearchSession'
 
 class ResearcherPreviews extends PreviewBase {
+  constructor (props) {
+    super(props)
+  }
+
   render () {
     return (
       <div>

--- a/app/javascript/components/ResearcherPreviews/index.js
+++ b/app/javascript/components/ResearcherPreviews/index.js
@@ -5,8 +5,8 @@ import FindOutMore from '../Shared/FindOutMore'
 import WhatHappensInThisResearchSession from '../Shared/WhatHappensInThisResearchSession'
 
 class ResearcherPreviews extends PreviewBase {
-  constructor (props) {
-    super(props)
+  componentName () {
+    return 'ResearcherPreviews'
   }
 
   render () {

--- a/app/javascript/components/Shared/PreviewBase.js
+++ b/app/javascript/components/Shared/PreviewBase.js
@@ -19,7 +19,7 @@ class PreviewBase extends React.Component {
 
   componentDidMount () {
     Array.from(
-      document.querySelectorAll(`[data-previewed-by=${this.componentName()}]`)
+      document.querySelectorAll(`[data-previewed-by=${this.constructor.name}]`)
     ).forEach(element => {
       element.oninput = this.handleInputChange.bind(this)
     })

--- a/app/javascript/components/Shared/PreviewBase.js
+++ b/app/javascript/components/Shared/PreviewBase.js
@@ -13,9 +13,13 @@ class PreviewBase extends React.Component {
     this.state = props
   }
 
+  componentName() {
+    throw new Error('componentName should be implemented in base classes')
+  }
+
   componentDidMount () {
     Array.from(
-      document.querySelectorAll(`[data-previewed-by=${this.constructor.name}]`)
+      document.querySelectorAll(`[data-previewed-by=${this.componentName()}]`)
     ).forEach(element => {
       element.oninput = this.handleInputChange.bind(this)
     })

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -23,7 +23,11 @@ module.exports = merge(sharedConfig, {
 
       output: {
         comments: false
-      }
+      },
+
+      uglifyOptions: {
+        mangle: false
+      },
     }),
 
     new CompressionPlugin({


### PR DESCRIPTION
Events are broken in staging and deployment branches, we assume because of our use of `constructor.name` (though we're unsure why dev and test and CI continue to work).

Test this hypothesis with `ResearcherPreviews` and an explicit constructor.