### PR TITLE
Fix live previews broken by PreviewBase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [BUG] - [Change 'review' consent form heading to 'Consent form'](https://trello.com/c/2Hjw3duY/294-change-review-consent-form-heading-to-consent-form)
 * [FEATURE] - [Live preview: Topic / Purpose](https://trello.com/c/JiSAAKBv/256-3-live-preview-topic-purpose)
 * [BUG] - [Researcher preview phone number/word missing](https://trello.com/c/Vt4JdtH5/293-bugs-researcher-preview)
+* [BUG] - [Live previews broken in every live environment](https://trello.com/c/BV2jgy9O/295-live-previews-broken-in-every-live-environment)
 
 # 0.5.0 / 2017-11-16
 

--- a/app/javascript/components/ResearcherPreviews/index.js
+++ b/app/javascript/components/ResearcherPreviews/index.js
@@ -5,6 +5,10 @@ import FindOutMore from '../Shared/FindOutMore'
 import WhatHappensInThisResearchSession from '../Shared/WhatHappensInThisResearchSession'
 
 class ResearcherPreviews extends PreviewBase {
+  componentName () {
+    return 'ResearcherPreviews'
+  }
+
   render () {
     return (
       <div>

--- a/app/javascript/components/Shared/PreviewBase.js
+++ b/app/javascript/components/Shared/PreviewBase.js
@@ -13,6 +13,10 @@ class PreviewBase extends React.Component {
     this.state = props
   }
 
+  componentName () {
+    throw new Error('componentName should be implemented in derived classes')
+  }
+
   componentDidMount () {
     Array.from(
       document.querySelectorAll(`[data-previewed-by=${this.constructor.name}]`)

--- a/app/javascript/components/TopicPurposePreviews/index.js
+++ b/app/javascript/components/TopicPurposePreviews/index.js
@@ -4,6 +4,10 @@ import PreviewBase from '../Shared/PreviewBase'
 import Output from '../Shared/Output'
 
 class TopicPurposePreviews extends PreviewBase {
+  componentName () {
+    return 'TopicPurposePreviews'
+  }
+
   render () {
     return (
       <div>


### PR DESCRIPTION
# [Live previews broken in every live environment](https://trello.com/c/BV2jgy9O/295-live-previews-broken-in-every-live-environment)

# What did you do?

Tried to get live preview working on staging

# What did you expect to happen?

That live preview worked

# What actually happened?

Live preview remained static.

We were relying on `this.constructor.name` to wire up our oninput events
unobtrusively, but uglifier mangles those names by default in every
environment outside of test, CI and dev.

Mandate a componentName method which must return the same name as as the
class.