### PR TITLE
Preview storing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.7.0 / Unreleased
+
+* [FEATURE] - [Live preview: Storing](https://trello.com/c/2RNcewZH)
+
 # 0.6.0 / 2017-12-14
 
 * [FEATURE] - [Live preview: Researcher](https://trello.com/c/T2MeDlYY/255-13-live-preview-researcher)

--- a/app/helpers/barnardos/action_view/form_helper.rb
+++ b/app/helpers/barnardos/action_view/form_helper.rb
@@ -111,7 +111,8 @@ module Barnardos
             should_autofocus = options[:autofocus_first_item] && on_first_item
             on_first_item = false
             content_tag :div, class: 'radio-group__choice' do
-              b.radio_button(class: 'radio-group__input', autofocus: should_autofocus) +
+              radio_button_options = { class: 'radio-group__input', autofocus: should_autofocus }
+              b.radio_button(radio_button_options.merge(options[:input] || {})) +
                 b.label(class: 'radio-group__label')
             end
           end

--- a/app/javascript/components/RecordingMethodsPreviews/index.test.js
+++ b/app/javascript/components/RecordingMethodsPreviews/index.test.js
@@ -166,7 +166,7 @@ describe('RecordingMethodsPreviews', () => {
         //   resulting event
         beforeEach(() => {
           props['recording_methods'] = ['voice', 'video', 'other']
-          recordingMethodsPreviews().instance().handleTextChange({
+          recordingMethodsPreviews().instance().handleTextOrRadioChange({
             target: {
               name: 'research_session[other_recording_method]', value: 'a new other value'
             }

--- a/app/javascript/components/RecordingMethodsPreviews/index.test.js
+++ b/app/javascript/components/RecordingMethodsPreviews/index.test.js
@@ -64,7 +64,7 @@ describe('RecordingMethodsPreviews', () => {
       it('has a li for items', () => {
         expect(recordingMethodsPreviews()).to.contain(
           <li>
-            <output>
+            <output data-field="recording_methods">
               <a className="editable" href="/path/to/rails/recording_methods">
                 voice recording
               </a>
@@ -76,7 +76,7 @@ describe('RecordingMethodsPreviews', () => {
       it('has a li for the "other" item', () => {
         expect(recordingMethodsPreviews()).to.contain(
           <li>
-            <output>
+            <output data-field="other_recording_method">
               <a className="editable" href="/path/to/rails/recording_methods">
                 some other recording method
               </a>
@@ -87,8 +87,10 @@ describe('RecordingMethodsPreviews', () => {
 
       it('has a sentence with the checked items', () => {
         expect(recordingMethodsPreviews()).to.contain(
-          <output>
-            voice recording, video recording, and some other recording method
+          <output data-field="recording_methods">
+            <a className="editable" href="/path/to/rails/recording_methods">
+              voice recording, video recording, and some other recording method
+            </a>
           </output>
         )
       })
@@ -119,7 +121,8 @@ describe('RecordingMethodsPreviews', () => {
             'voice': 'the voice',
             'video': 'the video',
             'another_thing': 'another thing'
-          }
+          },
+          finalPreview: false
         }
       })
 
@@ -142,9 +145,9 @@ describe('RecordingMethodsPreviews', () => {
         it('adds that value to the list in order', () => {
           expect(recordingMethodsPreviews()).to.contain(
             <ul className="bullet-point-list">
-              <li><output className="reactive-preview__highlight">the voice</output></li>
-              <li><output className="reactive-preview__highlight">the video</output></li>
-              <li><output className="reactive-preview__highlight">another thing</output></li>
+              <li><output className="reactive-preview__highlight" data-field="recording_methods">the voice</output></li>
+              <li><output className="reactive-preview__highlight" data-field="recording_methods">the video</output></li>
+              <li><output className="reactive-preview__highlight" data-field="recording_methods">another thing</output></li>
             </ul>
           )
         })
@@ -173,7 +176,7 @@ describe('RecordingMethodsPreviews', () => {
 
         it('changes the value in the list', () => {
           expect(recordingMethodsPreviews()).to.contain(
-            <output className="reactive-preview__highlight">
+            <output className="reactive-preview__highlight" data-field="other_recording_method">
               a new other value
             </output>
           )
@@ -181,7 +184,7 @@ describe('RecordingMethodsPreviews', () => {
 
         it('changes the value in the sentence', () => {
           expect(recordingMethodsPreviews()).to.contain(
-            <output className="reactive-preview__highlight">
+            <output className="reactive-preview__highlight" data-field="recording_methods">
               the voice, the video, and a new other value
             </output>
           )

--- a/app/javascript/components/ResearcherPreviews/index.test.js
+++ b/app/javascript/components/ResearcherPreviews/index.test.js
@@ -65,7 +65,7 @@ describe('ResearcherPreviews', () => {
       })
       it('renders an editLink with the supplied rails route for the name', () => {
         expect(researcherPreviews()).to.contain(
-          <output>
+          <output data-field="researcher_name">
             <a className="editable" href="/rails/path/to/researcher_name">Rachael Researcher</a>
           </output>
         )

--- a/app/javascript/components/ResearcherPreviews/index.test.js
+++ b/app/javascript/components/ResearcherPreviews/index.test.js
@@ -101,7 +101,7 @@ describe('ResearcherPreviews', () => {
         //   resulting event
 
         it('changes the researcher name', () => {
-          researcherPreviews().instance().handleTextChange({
+          researcherPreviews().instance().handleTextOrRadioChange({
             target: { name: 'research_session[researcher_name]', value: 'Leanne' }
           })
 

--- a/app/javascript/components/Shared/DisplayAdditionalCopy.js
+++ b/app/javascript/components/Shared/DisplayAdditionalCopy.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const DisplayAdditionalCopy = ({finalPreview, content}) => {
+  return finalPreview ? content : <span>&hellip;</span>
+}
+
+DisplayAdditionalCopy.propTypes = {
+  content: PropTypes.string,
+  finalPreview: PropTypes.bool
+}
+
+export default DisplayAdditionalCopy

--- a/app/javascript/components/Shared/DisplayAdditionalCopy.test.js
+++ b/app/javascript/components/Shared/DisplayAdditionalCopy.test.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import DisplayAdditionalCopy from './DisplayAdditionalCopy'
+
+describe('DisplayAdditionalCopy', () => {
+  describe('When on final preview', () => {
+    it('displays the content', () => {
+      const content = 'Display this content'
+      const mountedComponent = mount(
+        <DisplayAdditionalCopy
+          content={content}
+          finalPreview={true} />
+      )
+
+      expect(mountedComponent).to.contain(content)
+    })
+  })
+
+  describe('When on step', () => {
+    it('shows placeholder', () => {
+      const content = 'Do not display this'
+      const mountedComponent = mount(
+        <DisplayAdditionalCopy
+          content={content}
+          finalPreview={false} />
+      )
+
+      expect(mountedComponent).to.contain(<span>&hellip;</span>)
+    })
+  })
+})

--- a/app/javascript/components/Shared/Output.js
+++ b/app/javascript/components/Shared/Output.js
@@ -18,7 +18,7 @@ const Output = (props, attr, value) => {
   const optionalClass = props.finalPreview ? {} : { className: 'reactive-preview__highlight' }
 
   return (
-    <output {...optionalClass}>
+    <output {...optionalClass} data-field={attr}>
       {linkOrValue}
     </output>
   )

--- a/app/javascript/components/Shared/Output.test.js
+++ b/app/javascript/components/Shared/Output.test.js
@@ -21,7 +21,7 @@ describe('Output', () => {
       it('renders that property as an output', () => {
         const output = mount(Output(props, 'my_property'))
         expect(output).to.contain(
-          <output className="reactive-preview__highlight">
+          <output className="reactive-preview__highlight" data-field="my_property">
             this is my value
           </output>
         )
@@ -35,7 +35,7 @@ describe('Output', () => {
       it('renders that property as an output with a link to the path in editLinks', () => {
         const output = mount(Output(props, 'my_property'))
         expect(output).to.contain(
-          <output>
+          <output data-field="my_property">
             <a className="editable" href="/path/to/my_property">this is my value</a>
           </output>
         )
@@ -44,7 +44,7 @@ describe('Output', () => {
         it('renders the override but keeps the link', () => {
           const output = mount(Output(props, 'my_property', 'the override'))
           expect(output).to.contain(
-            <output>
+            <output data-field="my_property">
               <a className="editable" href="/path/to/my_property">the override</a>
             </output>
           )

--- a/app/javascript/components/Shared/PreviewBase.js
+++ b/app/javascript/components/Shared/PreviewBase.js
@@ -26,6 +26,8 @@ class PreviewBase extends React.Component {
     ).forEach(element => {
       if (element.type === 'checkbox') {
         element.onchange = this.handleCheckboxChange.bind(this)
+      } else if (element.type === 'radio') {
+        element.onchange = this.handleTextOrRadioChange.bind(this)
       } else {
         element.oninput = this.handleTextOrRadioChange.bind(this)
       }

--- a/app/javascript/components/Shared/PreviewBase.js
+++ b/app/javascript/components/Shared/PreviewBase.js
@@ -27,12 +27,12 @@ class PreviewBase extends React.Component {
       if (element.type === 'checkbox') {
         element.onchange = this.handleCheckboxChange.bind(this)
       } else {
-        element.oninput = this.handleTextChange.bind(this)
+        element.oninput = this.handleTextOrRadioChange.bind(this)
       }
     })
   }
 
-  handleTextChange (event) {
+  handleTextOrRadioChange (event) {
     const { target: { value, name: railsName } } = event
 
     const namePattern = /research_session\[(.+?)]/

--- a/app/javascript/components/Shared/WhichWeWillRecordUsingSentence.js
+++ b/app/javascript/components/Shared/WhichWeWillRecordUsingSentence.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import humanizeList from 'humanize-list'
 import sortAgainst from './sort-against'
+import Output from './Output'
 
 const WhichWeWillRecordUsingSentence = (props) => {
   let recordingMethodsSentence = ''
@@ -18,13 +19,12 @@ const WhichWeWillRecordUsingSentence = (props) => {
   }
 
   const childsIfUnable = props.able_to_consent ? '' : ' childʼs'
-  const options = props.finalPreview ? {} : { className: 'reactive-preview__highlight' }
 
   return (
     <li>
       I understand that my{childsIfUnable} activities during the research session may
       be observed and will be recorded. The data captured, in the form of{' '}
-      <output {...options}>{recordingMethodsSentence}</output>
+      {Output(props, 'recording_methods', recordingMethodsSentence)}
       {' '}will be used for current and future service development.
     </li>
   )

--- a/app/javascript/components/Shared/WillAnyoneKnowWhatISayInTheDiscussion.js
+++ b/app/javascript/components/Shared/WillAnyoneKnowWhatISayInTheDiscussion.js
@@ -4,6 +4,12 @@ import Output from './Output'
 import DisplayAdditionalCopy from './DisplayAdditionalCopy'
 
 const WillAnyoneKnowWhatISayInTheDiscussion = (props) => {
+  let sharedWithSentence = ''
+
+  if (props.shared_with) {
+    sharedWithSentence = props.shared_with_sentences[props.shared_with]
+  }
+
   return (
     <div className="reactive-container__preview">
       <section className='reactive-preview__section'>
@@ -15,7 +21,7 @@ const WillAnyoneKnowWhatISayInTheDiscussion = (props) => {
           />
         </p>
         <p>
-          {Output(props, 'shared_with')}
+          {Output(props, 'shared_with', sharedWithSentence)}
         </p>
         <p>
           Barnardo’s will hold research data for{' '}
@@ -37,6 +43,7 @@ const WillAnyoneKnowWhatISayInTheDiscussion = (props) => {
 WillAnyoneKnowWhatISayInTheDiscussion.propTypes = {
   shared_duration: PropTypes.string,
   shared_with: PropTypes.string,
+  shared_with_sentences: PropTypes.object,
   finalPreview: PropTypes.bool
 }
 

--- a/app/javascript/components/Shared/WillAnyoneKnowWhatISayInTheDiscussion.js
+++ b/app/javascript/components/Shared/WillAnyoneKnowWhatISayInTheDiscussion.js
@@ -13,7 +13,7 @@ const WillAnyoneKnowWhatISayInTheDiscussion = (props) => {
   return (
     <div className="reactive-container__preview">
       <section className='reactive-preview__section'>
-        <h3 className="reactive-preview__heading" id="storing">Will anyone know what they say in the discussion?</h3>
+        <h3 className="reactive-preview__heading" id="storing">{props.shared_title}</h3>
         <p>
           <DisplayAdditionalCopy
             content="The only people who will hear what you say in the session will be the researchers running the session, other young people taking part, and service workers facilitating the session."
@@ -44,6 +44,7 @@ WillAnyoneKnowWhatISayInTheDiscussion.propTypes = {
   shared_duration: PropTypes.string,
   shared_with: PropTypes.string,
   shared_with_sentences: PropTypes.object,
+  shared_title: PropTypes.string,
   finalPreview: PropTypes.bool
 }
 

--- a/app/javascript/components/Shared/WillAnyoneKnowWhatISayInTheDiscussion.js
+++ b/app/javascript/components/Shared/WillAnyoneKnowWhatISayInTheDiscussion.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Output from './Output'
+
+const WillAnyoneKnowWhatISayInTheDiscussion = (props) => {
+  return (
+    <div className="reactive-container__preview">
+      <section className='reactive-preview__section'>
+        <h3 className="reactive-preview__heading" id="storing">Will anyone know what they say in the discussion?</h3>
+        <p>
+          The only people who will hear what you say in the session will be the researchers
+          running the session, other young people taking part, and service workers
+          facilitating the session.
+        </p>
+        <p>
+          {Output(props, 'shared_with')}
+        </p>
+        <p>
+          Barnardo’s will hold research data for{' '}
+          {Output(props, 'shared_duration')}{' '}
+          after the closure of this project, after which it will
+          be deleted. Personal data is stored in a safe and secure way.
+        </p>
+        <p>
+          You can contact Jason Caplin to ask us to delete your personal data at any time.
+        </p>
+      </section>
+    </div>
+  )
+}
+
+WillAnyoneKnowWhatISayInTheDiscussion.propTypes = {
+  shared_duration: PropTypes.string,
+  shared_with: PropTypes.string,
+  finalPreview: PropTypes.bool
+}
+
+export default WillAnyoneKnowWhatISayInTheDiscussion

--- a/app/javascript/components/Shared/WillAnyoneKnowWhatISayInTheDiscussion.js
+++ b/app/javascript/components/Shared/WillAnyoneKnowWhatISayInTheDiscussion.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Output from './Output'
+import DisplayAdditionalCopy from './DisplayAdditionalCopy'
 
 const WillAnyoneKnowWhatISayInTheDiscussion = (props) => {
   return (
@@ -8,9 +9,10 @@ const WillAnyoneKnowWhatISayInTheDiscussion = (props) => {
       <section className='reactive-preview__section'>
         <h3 className="reactive-preview__heading" id="storing">Will anyone know what they say in the discussion?</h3>
         <p>
-          The only people who will hear what you say in the session will be the researchers
-          running the session, other young people taking part, and service workers
-          facilitating the session.
+          <DisplayAdditionalCopy
+            content="The only people who will hear what you say in the session will be the researchers running the session, other young people taking part, and service workers facilitating the session."
+            finalPreview={props.finalPreview}
+          />
         </p>
         <p>
           {Output(props, 'shared_with')}
@@ -22,7 +24,10 @@ const WillAnyoneKnowWhatISayInTheDiscussion = (props) => {
           be deleted. Personal data is stored in a safe and secure way.
         </p>
         <p>
-          You can contact Jason Caplin to ask us to delete your personal data at any time.
+          <DisplayAdditionalCopy
+            content="You can contact Jason Caplin to ask us to delete your personal data at any time."
+            finalPreview={props.finalPreview}
+          />
         </p>
       </section>
     </div>

--- a/app/javascript/components/Shared/WillAnyoneKnowWhatISayInTheDiscussion.js
+++ b/app/javascript/components/Shared/WillAnyoneKnowWhatISayInTheDiscussion.js
@@ -11,32 +11,30 @@ const WillAnyoneKnowWhatISayInTheDiscussion = (props) => {
   }
 
   return (
-    <div className="reactive-container__preview">
-      <section className='reactive-preview__section'>
-        <h3 className="reactive-preview__heading" id="storing">{props.shared_title}</h3>
-        <p>
-          <DisplayAdditionalCopy
-            content="The only people who will hear what you say in the session will be the researchers running the session, other young people taking part, and service workers facilitating the session."
-            finalPreview={props.finalPreview}
-          />
-        </p>
-        <p>
-          {Output(props, 'shared_with', sharedWithSentence)}
-        </p>
-        <p>
-          Barnardo’s will hold research data for{' '}
-          {Output(props, 'shared_duration')}{' '}
-          after the closure of this project, after which it will
-          be deleted. Personal data is stored in a safe and secure way.
-        </p>
-        <p>
-          <DisplayAdditionalCopy
-            content="You can contact Jason Caplin to ask us to delete your personal data at any time."
-            finalPreview={props.finalPreview}
-          />
-        </p>
-      </section>
-    </div>
+    <section className={ props.finalPreview ? '' : 'reactive-preview__section' }>
+      <h3 className={ props.finalPreview ? '' : 'reactive-preview__heading' } id="storing">{props.shared_title}</h3>
+      <p>
+        <DisplayAdditionalCopy
+          content={`The only people who will hear what ${props.you_or_your_child} ${props.say_or_says} in the session will be the researchers running the session, other young people taking part, and service workers facilitating the session.`}
+          finalPreview={props.finalPreview}
+        />
+      </p>
+      <p>
+        {Output(props, 'shared_with', sharedWithSentence)}
+      </p>
+      <p>
+        Barnardo’s will hold research data for{' '}
+        {Output(props, 'shared_duration')}{' '}
+        after the closure of this project, after which it will
+        be deleted. Personal data is stored in a safe and secure way.
+      </p>
+      <p>
+        <DisplayAdditionalCopy
+          content="You can contact Jason Caplin to ask us to delete your personal data at any time."
+          finalPreview={props.finalPreview}
+        />
+      </p>
+    </section>
   )
 }
 
@@ -45,7 +43,9 @@ WillAnyoneKnowWhatISayInTheDiscussion.propTypes = {
   shared_with: PropTypes.string,
   shared_with_sentences: PropTypes.object,
   shared_title: PropTypes.string,
-  finalPreview: PropTypes.bool
+  finalPreview: PropTypes.bool,
+  you_or_your_child: PropTypes.string,
+  say_or_says: PropTypes.string
 }
 
 export default WillAnyoneKnowWhatISayInTheDiscussion

--- a/app/javascript/components/StoringPreviews/index.js
+++ b/app/javascript/components/StoringPreviews/index.js
@@ -18,7 +18,8 @@ class StoringPreviews extends PreviewBase {
 }
 
 StoringPreviews.propTypes = {
-  shared_duration: PropTypes.string
+  shared_duration: PropTypes.string,
+  shared_with_sentences: PropTypes.object
 }
 
 export default StoringPreviews

--- a/app/javascript/components/StoringPreviews/index.js
+++ b/app/javascript/components/StoringPreviews/index.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import PreviewBase from '../Shared/PreviewBase'
+import WillAnyoneKnowWhatISayInTheDiscussion from '../Shared/WillAnyoneKnowWhatISayInTheDiscussion'
+
+class StoringPreviews extends PreviewBase {
+  componentName () {
+    return 'StoringPreviews'
+  }
+
+  render () {
+    return (
+      <div>
+        <WillAnyoneKnowWhatISayInTheDiscussion {...this.state } />
+      </div>
+    )
+  }
+}
+
+StoringPreviews.propTypes = {
+  shared_duration: PropTypes.string
+}
+
+export default StoringPreviews

--- a/app/javascript/components/StoringPreviews/index.js
+++ b/app/javascript/components/StoringPreviews/index.js
@@ -19,7 +19,11 @@ class StoringPreviews extends PreviewBase {
 
 StoringPreviews.propTypes = {
   shared_duration: PropTypes.string,
-  shared_with_sentences: PropTypes.object
+  shared_with_sentences: PropTypes.object,
+  shared_with: PropTypes.string,
+  able_to_consent: PropTypes.bool,
+  shared_title: PropTypes.string,
+  finalPreview: PropTypes.bool
 }
 
 export default StoringPreviews

--- a/app/javascript/components/StoringPreviews/index.test.js
+++ b/app/javascript/components/StoringPreviews/index.test.js
@@ -15,7 +15,10 @@ describe('StoringPreviews', () => {
 
   beforeEach(() => {
     props = {
-      shared_duration: undefined
+      shared_duration: undefined,
+      shared_with: undefined,
+      shared_with_sentences: undefined,
+      finalPreview: false
     }
     mountedStoringPreviews = undefined
   })
@@ -38,6 +41,10 @@ describe('StoringPreviews', () => {
       beforeEach(() => {
         props = {
           shared_duration: 'one year',
+          shared_with: 'anonymised',
+          shared_with_sentences: {
+            anonymised: 'anonymised sentence'
+          },
           editLinks: {
             shared_duration: '/path/to/rails/storing'
           },
@@ -46,19 +53,14 @@ describe('StoringPreviews', () => {
         mountedStoringPreviews = undefined
       })
 
-      it('has a total of two outputs, both are sentences', () => {
-        const outputs = storingPreviews().find('output')
-        expect(outputs.length).to.eql(2)
+      it('displays the shared duration content', () => {
+        const sharedDurationOutput = storingPreviews().find('output[data-field="shared_duration"]')
+        expect(sharedDurationOutput).text().to.eql(props.shared_duration)
       })
 
-      it('has an output for shared_duration', () => {
-        expect(storingPreviews()).to.contain(
-          <output data-field="shared_duration">
-            <a className="editable" href="/path/to/rails/storing">
-              one year
-            </a>
-          </output>
-        )
+      it('displays the shared_with sentence', () => {
+        const sharedWithOutput = storingPreviews().find('output[data-field="shared_with"]')
+        expect(sharedWithOutput).text().to.eql(props.shared_with_sentences.anonymised)
       })
     })
   })
@@ -66,7 +68,13 @@ describe('StoringPreviews', () => {
   describe('values changing', () => {
     beforeEach(() => {
       props = {
-        shared_duration: 'one year'
+        shared_duration: 'one year',
+        shared_with: 'anonymised',
+        shared_with_sentences: {
+          anonymised: 'anonymised sentence',
+          internal: 'internal sentence'
+        },
+        finalPreview: false
       }
     })
 
@@ -77,6 +85,14 @@ describe('StoringPreviews', () => {
         })
 
         expect(storingPreviews().find('output[data-field="shared_duration"]').text()).to.eql('two years')
+      })
+
+      it('changes the shared with sentence', () => {
+        storingPreviews().instance().handleTextOrRadioChange({
+          target: { name: 'research_session[shared_with]', value: 'internal' }
+        })
+
+        expect(storingPreviews().find('output[data-field="shared_with"]').text()).to.eql(props.shared_with_sentences.internal)
       })
     })
   })

--- a/app/javascript/components/StoringPreviews/index.test.js
+++ b/app/javascript/components/StoringPreviews/index.test.js
@@ -1,0 +1,83 @@
+import React from 'react'
+import StoringPreviews from './index.js'
+
+describe('StoringPreviews', () => {
+  let props
+  let mountedStoringPreviews
+  const storingPreviews = () => {
+    if (!mountedStoringPreviews) {
+      mountedStoringPreviews = mount(
+        <StoringPreviews {...props} />
+      )
+    }
+    return mountedStoringPreviews
+  }
+
+  beforeEach(() => {
+    props = {
+      shared_duration: undefined
+    }
+    mountedStoringPreviews = undefined
+  })
+
+  describe('the initial render state', () => {
+    describe('no props are given', () => {
+      it('renders a section as an area on the preview that could change', () => {
+        const sections = storingPreviews().find('section')
+        expect(sections.length).to.eql(1)
+      })
+
+      it('has two outputs, which are blank', () => {
+        const outputs = storingPreviews().find('output')
+        expect(outputs.length).to.equal(2)
+        outputs.forEach(output => expect(output.text()).to.be.empty)
+      })
+    })
+
+    describe('a radio button is selected and a year has been added', () => {
+      beforeEach(() => {
+        props = {
+          shared_duration: 'one year',
+          editLinks: {
+            shared_duration: '/path/to/rails/storing'
+          },
+          finalPreview: true
+        }
+        mountedStoringPreviews = undefined
+      })
+
+      it('has a total of two outputs, both are sentences', () => {
+        const outputs = storingPreviews().find('output')
+        expect(outputs.length).to.eql(2)
+      })
+
+      it('has an output for shared_duration', () => {
+        expect(storingPreviews()).to.contain(
+          <output data-field="shared_duration">
+            <a className="editable" href="/path/to/rails/storing">
+              one year
+            </a>
+          </output>
+        )
+      })
+    })
+  })
+
+  describe('values changing', () => {
+    beforeEach(() => {
+      props = {
+        shared_duration: 'one year'
+      }
+    })
+
+    describe('receipt of an input change', () => {
+      it('changes the shared duration', () => {
+        storingPreviews().instance().handleTextChange({
+          target: { name: 'research_session[shared_duration]', value: 'two years' }
+        })
+
+        expect(storingPreviews().find('output[data-field="shared_duration"]').text()).to.eql('two years')
+      })
+    })
+  })
+})

--- a/app/javascript/components/StoringPreviews/index.test.js
+++ b/app/javascript/components/StoringPreviews/index.test.js
@@ -72,7 +72,7 @@ describe('StoringPreviews', () => {
 
     describe('receipt of an input change', () => {
       it('changes the shared duration', () => {
-        storingPreviews().instance().handleTextChange({
+        storingPreviews().instance().handleTextOrRadioChange({
           target: { name: 'research_session[shared_duration]', value: 'two years' }
         })
 

--- a/app/javascript/components/TopicPurposePreviews/index.test.js
+++ b/app/javascript/components/TopicPurposePreviews/index.test.js
@@ -72,14 +72,14 @@ describe('TopicPurposePreviews', () => {
       })
       it('renders an editLink with the supplied rails route for the topic', () => {
         expect(topicPurposePreviews()).to.contain(
-          <output>
+          <output data-field="topic">
             <a className="editable" href="/rails/path/to/topic">{props.topic}</a>
           </output>
         )
       })
       it('renders an editLink with the supplied rails route for the purpose', () => {
         expect(topicPurposePreviews()).to.contain(
-          <output>
+          <output data-field="purpose">
             <a className="editable" href="/rails/path/to/purpose">{props.purpose}</a>
           </output>
         )

--- a/app/javascript/components/TopicPurposePreviews/index.test.js
+++ b/app/javascript/components/TopicPurposePreviews/index.test.js
@@ -103,7 +103,7 @@ describe('TopicPurposePreviews', () => {
         //   resulting event
 
         it('changes the topic', () => {
-          topicPurposePreviews().instance().handleTextChange({
+          topicPurposePreviews().instance().handleTextOrRadioChange({
             target: { name: 'research_session[topic]', value: 'a new topic' }
           })
 

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -146,32 +146,24 @@
     </section>
   <% end %>
 
-  <section>
-    <h3 id="confidential">
-      Will anyone know what <%= i_or_they %> say in the discussion?
-    </h3>
-
-    <p>
-      The only people who will hear what <%= you_or_your_child %> <%= say_or_says %> in the session
-      will be the researchers running the session, other young people taking part, and
-      service workers facilitating the session.
-    </p>
-
-    <p>
-      <%= edit_link_for(:shared_with) do %>
-        <%= shared_with_lookup(@research_session.shared_with) %>
-      <% end %>
-    </p>
-
-    <p>
-      Barnardo’s will hold research data for <%= edit_link_for(:shared_duration) %>
-      after the closure of this project, after which it will be deleted.
-      Personal data is stored in a safe and secure way.
-    </p>
-    <p>
-      You can contact Jason Caplin to ask us to delete your personal data at any time.
-    </p>
-  </section>
+  <%=
+    react_component(
+      'Shared/WillAnyoneKnowWhatISayInTheDiscussion',
+      final_preview_params(:storing).merge(
+        able_to_consent: @research_session.able_to_consent?,
+        shared_with_sentences: {
+          anonymised: t('preview.shared_with.anonymised', person: you_or_your_child),
+          team: t('preview.shared_with.team'),
+          internal: t('preview.shared_with.internal'),
+          external: t('preview.shared_with.external')
+        },
+        shared_title: "Will anyone know what #{i_or_they} say in the discussion?",
+        you_or_your_child: you_or_your_child,
+        say_or_says: say_or_says
+      ),
+      { prerender: true }
+    )
+  %>
 
   <section>
     <h3 id="sharing-information">Sharing information</h3>

--- a/app/views/research_sessions/questions/storing.html.erb
+++ b/app/views/research_sessions/questions/storing.html.erb
@@ -8,7 +8,12 @@
         <%= form.radio_group_vertical \
             :shared_with,
             SharedWith::NAME_VALUES,
-            { autofocus_first_item: true },
+            {
+              autofocus_first_item: true,
+              input: {
+                'data-previewed-by' => 'StoringPreviews'
+              }
+            },
             legend: t('helpers.legend.research_session.shared_with')
         %>
 

--- a/app/views/research_sessions/questions/storing.html.erb
+++ b/app/views/research_sessions/questions/storing.html.erb
@@ -33,7 +33,13 @@
           react_component(
             'StoringPreviews',
             current_step_params.merge(
-              able_to_consent: false # Fixed – we don't have an idea until preview
+              able_to_consent: false,
+              shared_with_sentences: {
+                anonymised: t('preview.shared_with.anonymised', person: 'you'),
+                team: t('preview.shared_with.team'),
+                internal: t('preview.shared_with.internal'),
+                external: t('preview.shared_with.external')
+              }
             )
           )
         %>

--- a/app/views/research_sessions/questions/storing.html.erb
+++ b/app/views/research_sessions/questions/storing.html.erb
@@ -39,7 +39,8 @@
                 team: t('preview.shared_with.team'),
                 internal: t('preview.shared_with.internal'),
                 external: t('preview.shared_with.external')
-              }
+              },
+              shared_title: 'Will anyone know what I say in the discussion?'
             )
           )
         %>

--- a/app/views/research_sessions/questions/storing.html.erb
+++ b/app/views/research_sessions/questions/storing.html.erb
@@ -3,24 +3,37 @@
   <%= render 'shared/error_summary' %>
   <h1 class="page-heading">Storing</h1>
   <%= barnardos_form_with model: @research_session, url: wizard_path do |form| %>
+    <div class="reactive-container">
+      <div class="reactive-container__form">
+        <%= form.radio_group_vertical \
+            :shared_with,
+            SharedWith::NAME_VALUES,
+            { autofocus_first_item: true },
+            legend: t('helpers.legend.research_session.shared_with')
+        %>
 
-    <%= form.radio_group_vertical \
-        :shared_with,
-        SharedWith::NAME_VALUES,
-        { autofocus_first_item: true },
-        legend: t('helpers.legend.research_session.shared_with')
-    %>
-
-    <%= form.labelled_text_field \
-        :shared_duration,
-        label_options: {
-          hint: t('helpers.hint.research_session.shared_duration')
-        },
-        text_options: {
-          placeholder: t('helpers.placeholder.research_session.shared_duration'),
-        }
-    %>
-
+        <%= form.labelled_text_field \
+            :shared_duration,
+            label_options: {
+              hint: t('helpers.hint.research_session.shared_duration')
+            },
+            text_options: {
+              placeholder: t('helpers.placeholder.research_session.shared_duration'),
+              'data-previewed-by' => 'StoringPreviews'
+            }
+        %>
+      </div>
+      <div class="reactive-container__preview">
+        <%=
+          react_component(
+            'StoringPreviews',
+            current_step_params.merge(
+              able_to_consent: false # Fixed – we don't have an idea until preview
+            )
+          )
+        %>
+      </div>
+    </div>
     <%= render 'button_bar' %>
   <% end %>
 </div>


### PR DESCRIPTION
# [Live Preview: Storing](https://trello.com/c/2RNcewZH)

Implements live preview for the "storing" step, we've also made the following changes;

* Refactored <Output> to include `data-field` to return field names (to help with testing).
* Updated radio button helper code to accept input params
* Changed `handleTextChange` to `handleTextOrRadioChange` 

<img width="787" alt="screen shot 2017-12-19 at 15 44 55" src="https://user-images.githubusercontent.com/456902/34165174-74c891d0-e4d3-11e7-9096-0a5d3fc4dc66.png">
