### PR TITLE
CHORE: Unvarying params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.7.0 / Unreleased
 
 * [FEATURE] - [Live preview: Storing](https://trello.com/c/2RNcewZH)
+* [CHORE] - [Unvarying parameters](https://github.com/barnardos/consent-form-builder-rails/pull/194)
 
 # 0.6.0 / 2017-12-14
 

--- a/app/helpers/research_sessions_helper.rb
+++ b/app/helpers/research_sessions_helper.rb
@@ -92,6 +92,9 @@ private
           SharedWith::NAME_VALUES.keys.each_with_object({}) do |attr, result|
             result[attr.to_sym] = I18n.t("preview.shared_with.#{attr}", person: you_or_your_child)
           end
+      },
+      recording: {
+        all_recording_methods: RecordingMethods::NAME_VALUES
       }
     }
     unvarying_params[step] || {}

--- a/app/helpers/research_sessions_helper.rb
+++ b/app/helpers/research_sessions_helper.rb
@@ -1,10 +1,12 @@
 module ResearchSessionsHelper
   def current_step_params
     component_params(*flat_params(step))
+      .merge(unvarying_params(step))
   end
 
   def final_preview_params(step)
     component_params(*flat_params(step), final_preview: true)
+      .merge(unvarying_params(step))
   end
 
   def edit_link_for(attr, &block)
@@ -61,6 +63,22 @@ private
     ResearchSession::Steps::PARAMS[step].flat_map do |param|
       param.is_a?(Hash) ? param.keys : param
     end
+  end
+
+  ##
+  # For any given step, provide params that would not vary called
+  # from live preview/final preview to avoid duplication
+  UNVARYING_PARAMS = {
+    topic: {
+      labels: {
+        topic: I18n.t('research_session_attr_labels.topic'),
+        purpose: I18n.t('research_session_attr_labels.purpose')
+      }
+    }
+  }.freeze
+
+  def unvarying_params(step)
+    UNVARYING_PARAMS[step] || {}
   end
 
   ##

--- a/app/helpers/research_sessions_helper.rb
+++ b/app/helpers/research_sessions_helper.rb
@@ -2,11 +2,13 @@ module ResearchSessionsHelper
   def current_step_params
     component_params(*flat_params(step))
       .merge(unvarying_params(step))
+      .merge(able_to_consent: false)
   end
 
   def final_preview_params(step)
     component_params(*flat_params(step), final_preview: true)
       .merge(unvarying_params(step))
+      .merge(able_to_consent: @research_session.able_to_consent?)
   end
 
   def edit_link_for(attr, &block)

--- a/app/helpers/research_sessions_helper.rb
+++ b/app/helpers/research_sessions_helper.rb
@@ -58,9 +58,9 @@ module ResearchSessionsHelper
 private
 
   def flat_params(step)
-    ResearchSession::Steps::PARAMS[step].map do |param|
+    ResearchSession::Steps::PARAMS[step].flat_map do |param|
       param.is_a?(Hash) ? param.keys : param
-    end.flatten
+    end
   end
 
   ##

--- a/app/helpers/research_sessions_helper.rb
+++ b/app/helpers/research_sessions_helper.rb
@@ -33,28 +33,37 @@ module ResearchSessionsHelper
     I18n.t("preview.shared_with.#{shared_with}", person: you_or_your_child)
   end
 
+  ##
+  # On final preview the research session has a presenter that can
+  # respond to able_to_consent?. In live previews this is not the case
+  # and we need to default to no consent.
+  #
+  def able_to_consent?
+    @research_session.respond_to?(:able_to_consent?) ? @research_session.able_to_consent? : false
+  end
+
   def you_or_your_child
-    @research_session.able_to_consent? ? 'you' : 'your child/the child in your care'
+    able_to_consent? ? 'you' : 'your child/the child in your care'
   end
 
   def your_or_your_childs
-    @research_session.able_to_consent? ? 'your' : "your child's/the child in your care's"
+    able_to_consent? ? 'your' : "your child's/the child in your care's"
   end
 
   def you_or_they
-    @research_session.able_to_consent? ? 'you' : 'they'
+    able_to_consent? ? 'you' : 'they'
   end
 
   def your_or_their
-    @research_session.able_to_consent? ? 'your' : 'their'
+    able_to_consent? ? 'your' : 'their'
   end
 
   def i_or_they
-    @research_session.able_to_consent? ? 'I' : 'they'
+    able_to_consent? ? 'I' : 'they'
   end
 
   def say_or_says
-    @research_session.able_to_consent? ? 'say' : 'says'
+    able_to_consent? ? 'say' : 'says'
   end
 
 private
@@ -68,17 +77,22 @@ private
   ##
   # For any given step, provide params that would not vary called
   # from live preview/final preview to avoid duplication
-  UNVARYING_PARAMS = {
-    topic: {
-      labels: {
-        topic: I18n.t('research_session_attr_labels.topic'),
-        purpose: I18n.t('research_session_attr_labels.purpose')
+  def unvarying_params(step)
+    unvarying_params = {
+      topic: {
+        labels: {
+          topic: I18n.t('research_session_attr_labels.topic'),
+          purpose: I18n.t('research_session_attr_labels.purpose')
+        }
+      },
+      storing: {
+        shared_with_sentences:
+          SharedWith::NAME_VALUES.keys.each_with_object({}) do |attr, result|
+            result[attr.to_sym] = I18n.t("preview.shared_with.#{attr}", person: you_or_your_child)
+          end
       }
     }
-  }.freeze
-
-  def unvarying_params(step)
-    UNVARYING_PARAMS[step] || {}
+    unvarying_params[step] || {}
   end
 
   ##

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -61,8 +61,7 @@
   <% recording = capture do %>
     <%=
       react_component(
-        'Shared/WhichWeWillRecordUsingList',
-        final_preview_params(:recording).merge(all_recording_methods: RecordingMethods::NAME_VALUES),
+        'Shared/WhichWeWillRecordUsingList', final_preview_params(:recording),
         { prerender: true }
       )
     %>

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -146,12 +146,6 @@
       'Shared/WillAnyoneKnowWhatISayInTheDiscussion',
       final_preview_params(:storing).merge(
         able_to_consent: @research_session.able_to_consent?,
-        shared_with_sentences: {
-          anonymised: t('preview.shared_with.anonymised', person: you_or_your_child),
-          team: t('preview.shared_with.team'),
-          internal: t('preview.shared_with.internal'),
-          external: t('preview.shared_with.external')
-        },
         shared_title: "Will anyone know what #{i_or_they} say in the discussion?",
         you_or_your_child: you_or_your_child,
         say_or_says: say_or_says

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -248,9 +248,7 @@
     <%=
       react_component(
         'Shared/WhichWeWillRecordUsingSentence',
-        final_preview_params(:recording).merge(
-          all_recording_methods: RecordingMethods::NAME_VALUES
-        ),
+        final_preview_params(:recording),
         { prerender: true }
       )
     %>

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -32,12 +32,7 @@
   <section>
     <%= react_component(
         'TopicPurposePreviews',
-        final_preview_params(:topic).merge(
-          labels: {
-            topic: t('research_session_attr_labels.topic'),
-            purpose: t('research_session_attr_labels.purpose')
-          }
-        ),
+        final_preview_params(:topic),
         {
           prerender: true
         }

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -145,7 +145,6 @@
     react_component(
       'Shared/WillAnyoneKnowWhatISayInTheDiscussion',
       final_preview_params(:storing).merge(
-        able_to_consent: @research_session.able_to_consent?,
         shared_title: "Will anyone know what #{i_or_they} say in the discussion?",
         you_or_your_child: you_or_your_child,
         say_or_says: say_or_says
@@ -251,8 +250,7 @@
       react_component(
         'Shared/WhichWeWillRecordUsingSentence',
         final_preview_params(:recording).merge(
-          all_recording_methods: RecordingMethods::NAME_VALUES,
-          able_to_consent:  @research_session.able_to_consent?
+          all_recording_methods: RecordingMethods::NAME_VALUES
         ),
         { prerender: true }
       )

--- a/app/views/research_sessions/questions/recording.html.erb
+++ b/app/views/research_sessions/questions/recording.html.erb
@@ -31,8 +31,7 @@
           react_component(
             'RecordingMethodsPreviews',
             current_step_params.merge(
-              all_recording_methods: RecordingMethods::NAME_VALUES,
-              able_to_consent: false # Fixed – we don't have an idea until preview
+              all_recording_methods: RecordingMethods::NAME_VALUES
             )
           )
         %>

--- a/app/views/research_sessions/questions/recording.html.erb
+++ b/app/views/research_sessions/questions/recording.html.erb
@@ -28,12 +28,7 @@
       </div>
       <div class="reactive-container__preview">
         <%=
-          react_component(
-            'RecordingMethodsPreviews',
-            current_step_params.merge(
-              all_recording_methods: RecordingMethods::NAME_VALUES
-            )
-          )
+          react_component('RecordingMethodsPreviews', current_step_params)
         %>
       </div>
     </div>

--- a/app/views/research_sessions/questions/storing.html.erb
+++ b/app/views/research_sessions/questions/storing.html.erb
@@ -34,12 +34,6 @@
             'StoringPreviews',
             current_step_params.merge(
               able_to_consent: false,
-              shared_with_sentences: {
-                anonymised: t('preview.shared_with.anonymised', person: 'you'),
-                team: t('preview.shared_with.team'),
-                internal: t('preview.shared_with.internal'),
-                external: t('preview.shared_with.external')
-              },
               shared_title: 'Will anyone know what I say in the discussion?'
             )
           )

--- a/app/views/research_sessions/questions/storing.html.erb
+++ b/app/views/research_sessions/questions/storing.html.erb
@@ -33,7 +33,6 @@
           react_component(
             'StoringPreviews',
             current_step_params.merge(
-              able_to_consent: false,
               shared_title: 'Will anyone know what I say in the discussion?'
             )
           )

--- a/app/views/research_sessions/questions/topic.html.erb
+++ b/app/views/research_sessions/questions/topic.html.erb
@@ -29,15 +29,7 @@
       <div class="reactive-container__preview">
         <section class="reactive-preview__section">
           <%=
-            react_component(
-              'TopicPurposePreviews',
-              current_step_params.merge(
-                labels: {
-                  topic: t('research_session_attr_labels.topic'),
-                  purpose: t('research_session_attr_labels.purpose')
-                }
-              )
-            )
+            react_component('TopicPurposePreviews', current_step_params)
           %>
         </section>
       </div>

--- a/spec/helpers/research_sessions_helper_spec.rb
+++ b/spec/helpers/research_sessions_helper_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe ResearchSessionsHelper, :type => :helper do
   end
 
   describe '#unvarying_params' do
-    subject { helper.send(:unvarying_params, step) }
+    subject(:unvarying_params) { helper.send(:unvarying_params, step) }
 
     context 'the step has no unvarying params that would repeat across live/final preview' do
       let(:step) { :researcher }
@@ -94,6 +94,17 @@ RSpec.describe ResearchSessionsHelper, :type => :helper do
     context 'the step has unvarying params that would repeat across live/final preview' do
       let(:step) { :topic }
       it { is_expected.to have_key(:labels) }
+    end
+
+    context 'the step has params that should default to no consent' do
+      let(:step) { :storing }
+      it { is_expected.to have_key(:shared_with_sentences) }
+
+      it 'defaults anonymised to unable_to_consent?' do
+        expect(unvarying_params.dig(:shared_with_sentences, :anonymised)).to include(
+          'your child/the child in your care will not be identifiable'
+        )
+      end
     end
   end
 

--- a/spec/helpers/research_sessions_helper_spec.rb
+++ b/spec/helpers/research_sessions_helper_spec.rb
@@ -18,6 +18,15 @@ RSpec.describe ResearchSessionsHelper, :type => :helper do
       it 'calls component_params with all the parameters for the current step' do
         expect(helper).to receive(:component_params)
           .with(:topic, :purpose)
+          .and_return({})
+        helper.current_step_params
+      end
+
+      it 'calls unvarying_params for the current step' do
+        expect(helper).to receive(:component_params)
+          .with(:topic, :purpose)
+          .and_return({})
+        expect(helper).to receive(:unvarying_params).with(:topic).and_return({})
         helper.current_step_params
       end
     end
@@ -28,6 +37,7 @@ RSpec.describe ResearchSessionsHelper, :type => :helper do
       it 'calls component_params with all the parameters for the current step' do
         expect(helper).to receive(:component_params)
           .with(:other_recording_method, :recording_methods)
+          .and_return({})
         helper.current_step_params
       end
     end
@@ -36,22 +46,54 @@ RSpec.describe ResearchSessionsHelper, :type => :helper do
   describe '#final_preview_params' do
     context 'a normal step' do
       let(:step) { :topic }
+      let(:research_session) { double('ResearchSession') }
+
+      before do
+        assign(:research_session, research_session)
+      end
 
       it 'calls component_params with all the parameters for the current step' do
         expect(helper).to receive(:component_params)
           .with(:topic, :purpose, final_preview: true)
+          .and_return({})
         helper.final_preview_params(step)
       end
     end
 
     context 'a step with an array param' do
       let(:step) { :recording }
+      let(:research_session) { double('ResearchSession').as_null_object }
+
+      before do
+        assign(:research_session, research_session)
+      end
 
       it 'calls component_params with all the parameters for the current step' do
-        expect(helper).to receive(:component_params)
+        allow(helper).to receive(:component_params)
           .with(:other_recording_method, :recording_methods, final_preview: true)
+          .and_return({})
         helper.final_preview_params(step)
       end
+
+      it 'calls unvarying_params for the current step' do
+        allow(helper).to receive(:component_params).and_return({})
+        expect(helper).to receive(:unvarying_params).with(:recording).and_return({})
+        helper.final_preview_params(step)
+      end
+    end
+  end
+
+  describe '#unvarying_params' do
+    subject { helper.send(:unvarying_params, step) }
+
+    context 'the step has no unvarying params that would repeat across live/final preview' do
+      let(:step) { :researcher }
+      it { is_expected.to be_empty }
+    end
+
+    context 'the step has unvarying params that would repeat across live/final preview' do
+      let(:step) { :topic }
+      it { is_expected.to have_key(:labels) }
     end
   end
 

--- a/spec/helpers/research_sessions_helper_spec.rb
+++ b/spec/helpers/research_sessions_helper_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe ResearchSessionsHelper, :type => :helper do
   describe '#final_preview_params' do
     context 'a normal step' do
       let(:step) { :topic }
-      let(:research_session) { double('ResearchSession') }
+      let(:research_session) { double('ResearchSession', able_to_consent?: false) }
 
       before do
         assign(:research_session, research_session)


### PR DESCRIPTION
Since the start of live previews, we've been repeating ourselves across those live previews and the final preview with respect to certain params that didn't vary.

Introduce `ResearchSessionsHelper#unvarying_params` as a home for these such that the call sites for `react_component` no longer have this repetition.

The tests are a little noisier with respect to mocking but hopefully this helps with the cost of making copy changes that would require parameter changes in two places.

## Side effects

This also fixes a minor copy bug where the "storing" step in live preview mode would show you (out of step with the other live previews which would show "your child")

## Merry Christmas! 

🎄 🎅 🎁 

