### PR TITLE
Remove hard coded "my child" in consent form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [BUG] - [Preview highlighting not visible on some monitors](https://trello.com/c/Vu2Hi3mg)
 * [FEATURE] - [Only have 1 button to 'toggle' if respondent's ability to consent](https://trello.com/c/Rk2I2yIg/266-2-only-have-1-button-to-toggle-if-respondents-ability-to-consent)
 * [FEATURE] - [Add guidance paragraph to each section of consent form builder](https://trello.com/c/Mrkkr3ij/306-2-add-guidance-paragraph-to-each-section-of-consent-form-builder)
+* [BUG] - [Word "child" on a form version for self-consent](https://trello.com/c/monsCFE9/309-1-bug-word-child-on-a-form-version-for-self-consent)
 
 # 0.6.0 / 2017-12-14
 

--- a/app/views/research_sessions/preview.html.erb
+++ b/app/views/research_sessions/preview.html.erb
@@ -257,9 +257,9 @@
   </ul>
 
   <p>
-    I agree to my <%= 'childʼs' if @research_session.unable_to_consent? %>
+    I agree to my<%= ' childʼs' if @research_session.unable_to_consent? %>
     participation in this research and understand that
-    my childʼs data will be used as explained above.
+    my<%= ' childʼs' if @research_session.unable_to_consent? %> data will be used as explained above.
   </p>
 
   <%# Note: no whitespace between divs important here %>


### PR DESCRIPTION
# [BUG: word "child" on a form version for self-consent](https://trello.com/c/monsCFE9/309-1-bug-word-child-on-a-form-version-for-self-consent)