### PR TITLE
Add guidance paragraph to researcher & topic step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [BUG] - [Enforce HTTPS](https://trello.com/c/81qbObMx)
 * [BUG] - [Preview highlighting not visible on some monitors](https://trello.com/c/Vu2Hi3mg)
 * [FEATURE] - [Only have 1 button to 'toggle' if respondent's ability to consent](https://trello.com/c/Rk2I2yIg/266-2-only-have-1-button-to-toggle-if-respondents-ability-to-consent)
+* [FEATURE] - [Add guidance paragraph to each section of consent form builder](https://trello.com/c/Mrkkr3ij/306-2-add-guidance-paragraph-to-each-section-of-consent-form-builder)
 
 # 0.6.0 / 2017-12-14
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,6 +22,7 @@
 @import "barnardos/reactive-container";
 @import "barnardos/reactive-preview";
 @import "barnardos/preview-header";
+@import "barnardos/research-guidance";
 
 @import "app/session_preview";
 @import "app/consent_form_preview";

--- a/app/assets/stylesheets/barnardos/_research-guidance.scss
+++ b/app/assets/stylesheets/barnardos/_research-guidance.scss
@@ -1,0 +1,21 @@
+.research-guidance {
+  background: #e3f3cf;
+  margin-left: -8px;
+  margin-top: 16px;
+  padding: 16px 16px 16px 32px;
+  position: relative;
+
+  &::before {
+    background: #49671e;
+    content: "";
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 8px;
+  }
+
+  > p:first-child {
+    margin-top: 0;
+  }
+}

--- a/app/views/research_sessions/questions/researcher.html.erb
+++ b/app/views/research_sessions/questions/researcher.html.erb
@@ -2,6 +2,11 @@
 <div class="main-content">
   <%= render 'shared/error_summary' %>
   <h1 class="page-heading">Researcher</h1>
+
+  <div class="research-guidance">
+    <p>The researcher’s details will go directly on the sheet sent to participants of this session so they can contact you with any queries. The researcher should refer to the safeguarding code of conduct in <a href="http://b-hive.barnardos.org.uk/Interact/Pages/Content/Document.aspx?id=5100&SearchId=">BREC Guidance</a> so they are confident they know what to do if a safeguarding concern arises during the session.</p>
+  </div>
+
   <%= barnardos_form_with model: @research_session, url: wizard_path do |form| %>
 
       <fieldset class="fieldset">

--- a/app/views/research_sessions/questions/topic.html.erb
+++ b/app/views/research_sessions/questions/topic.html.erb
@@ -2,6 +2,11 @@
 <div class="main-content">
   <%= render 'shared/error_summary' %>
   <h1 class="page-heading">Topic</h1>
+
+  <div class="research-guidance">
+    <p>If your project will involve asking service users questions about their personal lives or about sensitive topics which could upset them or invade their privacy you should contact <a href="mailto:BREC@barnardos.org.uk">BREC</a> for a consultation.</p>
+  </div>
+
   <%= barnardos_form_with model: @research_session, url: wizard_path do |form| %>
     <div class="reactive-container">
       <div class="reactive-container__form">


### PR DESCRIPTION
# [Add guidance paragraph to each section of consent form builder](https://trello.com/c/Mrkkr3ij/306-2-add-guidance-paragraph-to-each-section-of-consent-form-builder)

Inform users of Barnardo's research policies and practices on the
researcher and topic step. Create a new visual layout for this
information to be presented in.

![image](https://user-images.githubusercontent.com/893208/34834164-31b1b46c-f6e9-11e7-8bdb-d4cc1c5053e2.png)
