### PR TITLE
Make Expenses validations require one expense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [BUG] - [Word "child" on a form version for self-consent](https://trello.com/c/monsCFE9/309-1-bug-word-child-on-a-form-version-for-self-consent)
 * [FEATURE] - [Live preview: Incentives](https://trello.com/c/4sfX3wZj/263-3-live-preview-incentives)
 * [CHORE] - [Update browser support in Babel](https://trello.com/c/RGm3Ssw0/282-2-update-browser-support-in-babel)
+* [BUG] - [Expenses values are not optional](https://trello.com/c/coasUFw2/299-3-bug-expenses-values-are-not-optional)
 
 # 0.6.0 / 2017-12-14
 

--- a/app/models/expenses.rb
+++ b/app/models/expenses.rb
@@ -1,0 +1,3 @@
+class Expenses
+  CATEGORIES = [:travel_expenses_limit, :food_expenses_limit, :other_expenses_limit].freeze
+end


### PR DESCRIPTION
# [BUG: expenses values are not optional](https://trello.com/c/coasUFw2/299-3-bug-expenses-values-are-not-optional)

Instead of required all expenses to be completed we allow the user to continue so long as one expense is filled in.