### PR TITLE
Improve which browsers to support inside of Babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,21 +1,4 @@
 {
-  "presets": [
-    [
-      "env",
-      {
-        "targets": {
-          "browsers": [
-            "> 1%",
-            "last 2 versions",
-            "not ie <= 8"
-          ]
-        }
-      }
-    ],
-    "stage-2",
-    "react"
-  ],
-  "plugins": [
-    "transform-runtime"
-  ]
+  "presets": ["env", "stage-2", "react"],
+  "plugins": ["transform-runtime"]
 }

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,5 @@
+# Browsers that we support.
+# If a browser as > 1% market share or is in the last 2 versions
+
+> 1%
+last 2 versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [FEATURE] - [Add guidance paragraph to each section of consent form builder](https://trello.com/c/Mrkkr3ij/306-2-add-guidance-paragraph-to-each-section-of-consent-form-builder)
 * [BUG] - [Word "child" on a form version for self-consent](https://trello.com/c/monsCFE9/309-1-bug-word-child-on-a-form-version-for-self-consent)
 * [FEATURE] - [Live preview: Incentives](https://trello.com/c/4sfX3wZj/263-3-live-preview-incentives)
+* [CHORE] - [Update browser support in Babel](https://trello.com/c/RGm3Ssw0/282-2-update-browser-support-in-babel)
 
 # 0.6.0 / 2017-12-14
 


### PR DESCRIPTION
# [Update browser support in Babel](https://trello.com/c/RGm3Ssw0/282-2-update-browser-support-in-babel)

Moves browser support into its own file `.browserslistrc` which tidies up `.babelrc` and allows for other systems to eventually use it.

Removes specific IE rules, favouring browsers in use and 2 the latest versions.