### PR TITLE
Style IE11 placeholder text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [FEATURE] - [Live preview: Incentives](https://trello.com/c/4sfX3wZj/263-3-live-preview-incentives)
 * [CHORE] - [Update browser support in Babel](https://trello.com/c/RGm3Ssw0/282-2-update-browser-support-in-babel)
 * [BUG] - [Expenses values are not optional](https://trello.com/c/coasUFw2/299-3-bug-expenses-values-are-not-optional)
+* [BUG] - [(IE11) placeholders look like filled in values](https://trello.com/c/dBIiI9aF/311-bug-ie11-placeholders-look-like-filled-in-values)
 
 # 0.6.0 / 2017-12-14
 

--- a/app/assets/stylesheets/barnardos/_textfield.scss
+++ b/app/assets/stylesheets/barnardos/_textfield.scss
@@ -60,6 +60,10 @@
   outline: none;
 }
 
+.textfield__input:-ms-input-placeholder {
+  color: #ddd;
+}
+
 .textfield__hint {
   color: $secondary-text;
   display: block;


### PR DESCRIPTION
# [(IE11) placeholders look like filled in values](https://trello.com/c/dBIiI9aF/311-bug-ie11-placeholders-look-like-filled-in-values)

Makes the text a lighter grey, by default a black colour was being used that looked too much like completed text.

<img width="406" alt="IE 11 Screenshot of new placeholder text colour" src="https://user-images.githubusercontent.com/456902/34952797-d8dfeac0-fa12-11e7-9f40-accfab330b6b.png">
