### PR TITLE
Use accessible colour for placeholder text in IE

### DIFF
--- a/app/assets/stylesheets/barnardos/_textfield.scss
+++ b/app/assets/stylesheets/barnardos/_textfield.scss
@@ -61,7 +61,7 @@
 }
 
 .textfield__input:-ms-input-placeholder {
-  color: #ddd;
+  color: #757575;
 }
 
 .textfield__hint {


### PR DESCRIPTION
Hotfix for IE placeholder bug in order to make it accessible.