### PR TITLE
Fix overflow issues with legends on IE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [CHORE] - [Update browser support in Babel](https://trello.com/c/RGm3Ssw0/282-2-update-browser-support-in-babel)
 * [BUG] - [Expenses values are not optional](https://trello.com/c/coasUFw2/299-3-bug-expenses-values-are-not-optional)
 * [BUG] - [(IE11) placeholders look like filled in values](https://trello.com/c/dBIiI9aF/311-bug-ie11-placeholders-look-like-filled-in-values)
+* [BUG] – [(IE11) text overlap on 'Where & when' step](https://trello.com/c/s8d4BT5q/310-bug-ie11-text-overlap-on-where-when-step)
 
 # 0.6.0 / 2017-12-14
 

--- a/app/assets/stylesheets/barnardos/_datefield.scss
+++ b/app/assets/stylesheets/barnardos/_datefield.scss
@@ -12,7 +12,7 @@
 }
 
 .datefield__label {
-  display: block;
+  display: inline-block;
   font-weight: normal;
   color: $black;
   margin-top: $gutter / 2;

--- a/app/views/research_sessions/questions/where_when.html.erb
+++ b/app/views/research_sessions/questions/where_when.html.erb
@@ -15,7 +15,7 @@
       <div class="reactive-container">
         <div class="reactive-container__form">
           <fieldset class="datefield">
-            <legend class="datefield__label">Please enter the time and date of the session (optional)</legend>
+            <legend class="datefield__label">Please enter the time and date of the session</legend>
             <%= form.labelled_text_field \
                     :when_text,
                     text_options: {


### PR DESCRIPTION
# [(IE11) text overlap on 'Where & when' step](https://trello.com/c/s8d4BT5q/310-bug-ie11-text-overlap-on-where-when-step)

Removes redundant text and also fixes an overflow issue on IE11.

<img width="451" alt="screen shot 2018-01-16 at 16 52 46" src="https://user-images.githubusercontent.com/456902/35001226-42e3dc4e-fade-11e7-9de4-874c399599bc.png">
