### PR TITLE
Force the fact we allow single expenses to pass

### DIFF
--- a/app/models/research_session.rb
+++ b/app/models/research_session.rb
@@ -76,7 +76,7 @@ class ResearchSession < ApplicationRecord
   def expenses_validation(category)
     other_expenses_used = Expenses::CATEGORIES
                           .reject { |expense| expense == category }
-                          .all? { |expense| send(expense).nil? || send(expense) }
+                          .all? { |expense| send(expense).blank? }
     send(category).present? || (expenses_enabled && reached_step?(:expenses) && other_expenses_used)
   end
 end

--- a/spec/models/research_session_spec.rb
+++ b/spec/models/research_session_spec.rb
@@ -222,6 +222,19 @@ RSpec.describe ResearchSession, type: :model do
             expect(session.errors[:other_expenses_limit].first).to eql('is not a number')
           end
         end
+
+        context 'one valid expense is provided' do
+          let(:set_attrs) do
+            {
+              expenses_enabled: true,
+              travel_expenses_limit: '10.00',
+              food_expenses_limit: nil,
+              other_expenses_limit: nil
+            }
+          end
+
+          it { is_expected.to be_valid }
+        end
       end
 
       describe 'validating the incentives step' do


### PR DESCRIPTION
# [BUG: expenses values are not optional](https://trello.com/c/coasUFw2/299-3-bug-expenses-values-are-not-optional)

We had written code to try and allow single expenses to pass validation but it wasn't being enforced on production. This change writes a test to check the validations and fixes the issue in general

Related to (old) PR https://github.com/barnardos/consent-form-builder-rails/pull/207

Apologies to @kittysquee who noticed this weirdness during a code review after it had been merged and I didn't take immediate action then.