### PR TITLE
Make sure preview can 404

### DIFF
--- a/app/controllers/research_sessions_controller.rb
+++ b/app/controllers/research_sessions_controller.rb
@@ -1,6 +1,4 @@
 class ResearchSessionsController < ApplicationController
-  rescue_from ActiveRecord::RecordNotFound, with: :plain_404
-
   def new
     @research_session = ResearchSession.new
     return unless params[:from_existing].present?
@@ -56,7 +54,7 @@ private
   end
 
   def current_research_session
-    ResearchSession.find_by(slug: research_session_slug)
+    ResearchSession.find_by!(slug: research_session_slug)
   end
 
   def first_question_path
@@ -66,10 +64,5 @@ private
   def plain_400
     render status: 400,
            plain: %(Research Session "#{research_session_slug}" can't have a copy yet)
-  end
-
-  def plain_404
-    render status: 404,
-           plain: %(Research Session "#{research_session_slug}" not found)
   end
 end

--- a/spec/controllers/research_sessions_controller_spec.rb
+++ b/spec/controllers/research_sessions_controller_spec.rb
@@ -54,8 +54,8 @@ describe ResearchSessionsController, type: :controller do
         { research_session_id: 'i-dont-exist', research_session: { name: 'I do not exist' } }
       end
 
-      it '404s' do
-        expect(response.status).to eql(404)
+      it 'redirects to 404 page' do
+        expect(response.status).to eql(302)
       end
     end
 


### PR DESCRIPTION
# [BUG: 404s for research sessions actually 500](https://trello.com/c/S08RNn5r/242-3-bug-404s-for-research-sessions-actually-500)

Preview wasn't 404ing as we would have expected it would. This was because `research_session_controller` was handling 404 in its own unique way. This change removes that logic from the controller so it follows the same logic as the rest of the system.
