### PR TITLE
Use system font when printing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.8.1 / Unreleased
+
+* [BUG] - [Printing occasionally confused letters](https://trello.com/c/tF5zdsHM)
+
 # 0.8.0 / 2018-02-12
 
 * [CHORE] - Add additional PostgreSQL details to README

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -23,3 +23,30 @@ p {
   color: inherit;
   text-decoration: none;
 }
+
+html {
+  font-family: Verdana;
+  font-size: 16px;
+}
+
+h1,
+.page-heading {
+  font-size: 42px;
+}
+
+h3 {
+  font-size: 22px;
+}
+
+p,
+.bullet-point-list > *,
+.numbered-list > *,
+.definition-list dt,
+.definition-list dd {
+  font-size: 16px;
+}
+
+.editable {
+  background: none;
+  padding: 0;
+}

--- a/app/javascript/components/TopicPurposePreviews/index.test.js
+++ b/app/javascript/components/TopicPurposePreviews/index.test.js
@@ -13,7 +13,7 @@ describe("TopicPurposePreviews", () => {
 
   /* I18n labels */
   const labels = {
-    topic: "Barnardo's is doing research to learn about",
+    topic: "Barnardoʼs is doing research to learn about",
     purpose: "so that we can"
   };
 
@@ -64,7 +64,7 @@ describe("TopicPurposePreviews", () => {
 
       it("renders the topic and purpose in a readable sentence", () => {
         expect(topicPurposePreviews().text()).to.contain(
-          `Barnardo's is doing research to learn about ` +
+          `Barnardoʼs is doing research to learn about ` +
             `${props.topic} so that we can ${props.purpose}`
         );
       });

--- a/app/models/shared_with.rb
+++ b/app/models/shared_with.rb
@@ -1,8 +1,8 @@
 class SharedWith
   NAME_VALUES = HashWithIndifferentAccess.new(
     anonymised: 'anonymised as we process it',
-    team:       'shared with the research team at Barnardo\'s',
-    internal:   'shared with other teams in Barnardo\'s',
+    team:       'shared with the research team at Barnardoʼs',
+    internal:   'shared with other teams in Barnardoʼs',
     external:   'used in external publications'
   )
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
 
 <header role="banner" id="global-header">
   <div id="global-header__logo">
-    <%= image_tag 'barnardos-logo.svg', alt: 'Barnardos logo' %>
+    <%= image_tag 'barnardos-logo.svg', alt: 'Barnardoʼs logo' %>
   </div>
   <div id="global-header__menu"></div>
 </header>
@@ -69,5 +69,3 @@
 
 </body>
 </html>
-
-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,7 +45,7 @@ en:
     researcher_other_name: 'Full name'
     researcher_phone: 'Telephone number (optional)'
     researcher_email: 'Email'
-    topic: "Barnardo's is doing research to learn about"
+    topic: "Barnardoʼs is doing research to learn about"
     purpose: 'so that we can'
     methodologies: 'How will you be gathering information?'
     other_methodology: "What is the other methodology?"

--- a/features/support/step_completions.rb
+++ b/features/support/step_completions.rb
@@ -33,7 +33,7 @@ module StepCompletions
       Whereas this becomes its own p
     TEXT_WITH_DOUBLE_AND_SINGLE_LINEBREAK
 
-    fill_in "Barnardo's is doing research to learn about", with: @topic
+    fill_in 'Barnardoʼs is doing research to learn about', with: @topic
 
     @purpose = <<~TEXT_WITH_DOUBLE_AND_SINGLE_LINEBREAK
       PURPOSE: Fresnel lenses and the under-5s

--- a/spec/helpers/barnardos/action_view/form_helper_spec.rb
+++ b/spec/helpers/barnardos/action_view/form_helper_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Barnardos::ActionView::FormHelper, type: :helper do
 
       it 'labels according to en.yml' do
         expect(rendered).to have_tag(
-          'label', text: "Barnardo's is doing research to learn about"
+          'label', text: 'Barnardoʼs is doing research to learn about'
         )
       end
 


### PR DESCRIPTION
# [Information sheet prints with an error on second heading: 'Consentf orm' rather than 'Consent form'](https://trello.com/c/tF5zdsHM)

Uses a system font (Verdana) when printed. This required some sizing changes to be made to accommodate Verdana being larger when used than ProximaNova.

Some other small changes were made:

* A tick was being used for "Barnardo's", this has been replaced with an apostrophe
* Padding was being added to editable text, when printed editable doesn't make sense and the padding looked off when characters were no longer aligned.

This solution has been tested against  `Kyocera TASKalfa 5052ci KM4C35C6` which was the printer that was reported to cause this error.

## Example

This example shows the improved apostrophe and no padding on text inputs.

<img width="673" alt="screen shot 2018-02-12 at 16 33 33" src="https://user-images.githubusercontent.com/456902/36107630-9bd81e48-1012-11e8-8695-d2719275fa7c.png">
