### PR TITLE
Adds Google Analytics tracking to project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.8.1 / Unreleased
 
 * [BUG] - [Printing occasionally confused letters](https://trello.com/c/tF5zdsHM)
+* [CHORE] - [Add Google Analytics](https://trello.com/c/1cgqN4DP)
 
 # 0.8.0 / 2018-02-12
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,6 +8,7 @@
 // layout file, like app/views/layouts/application.html.erb
 
 require("../vendor/hotjar");
+require("../vendor/google_analytics");
 require("../lib/exit_warn");
 
 const HighlightControl = require("../components/highlightcontrol");

--- a/app/javascript/vendor/google_analytics.js
+++ b/app/javascript/vendor/google_analytics.js
@@ -1,0 +1,18 @@
+(function() {
+  const head = document.getElementsByTagName("head")[0];
+  const googleAnalyticsCode = window.googleAnalyticsCode || "UA-000000-00";
+
+  let script = document.createElement("script");
+  script.async = 1;
+  script.src =
+    "https://www.googletagmanager.com/gtag/js?id=" + googleAnalyticsCode;
+
+  head.appendChild(script);
+
+  window.dataLayer = window.dataLayer || [];
+  function gtag() {
+    dataLayer.push(arguments);
+  }
+  gtag("js", new Date());
+  gtag("config", googleAnalyticsCode);
+})();

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -61,6 +61,10 @@
   </div>
 </main>
 
+<script>
+  window.googleAnalyticsCode = '<%= ENV['GOOGLE_ANALYTICS_CODE'] %>';
+</script>
+
 <%= javascript_pack_tag 'application' %>
 
 <footer id="global-footer__release">


### PR DESCRIPTION
# [Add Google Analytics](https://trello.com/c/1cgqN4DP)

Adds Google Analytics tracking code to the project. Using the same conventions that were put in place for adding HotJar code.

* Uses the ENV setting of `GOOGLE_ANALYTICS_CODE`, this has been to be added to Heroku